### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Format


### PR DESCRIPTION
Potential fix for [https://github.com/Tgenz1213/ArchGuard/security/code-scanning/3](https://github.com/Tgenz1213/ArchGuard/security/code-scanning/3)

In general, the fix is to explicitly define the `permissions` for the `GITHUB_TOKEN` in the workflow, limiting them to the least privilege needed. For a CI workflow that only checks out code, runs linters, tests, and builds artifacts without writing back to GitHub, `contents: read` is sufficient and typically recommended.

The best fix here is to add a root-level `permissions` block, so it applies to all jobs (`lint`, `test`, and `build`) without altering their behavior. Place it after the `on:` block and before `jobs:` in `.github/workflows/ci.yml`. No existing steps need modification, and no additional scopes like `pull-requests: write` are required since nothing in the jobs writes to PRs or the repository. No imports or extra methods are needed because this is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  between line 10 (the blank line after the `on:` configuration) and line 11 (`jobs:`). This will restrict `GITHUB_TOKEN` to read-only repository contents for all jobs, satisfying CodeQL’s recommendation and maintaining existing functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
