### PR TITLE
feat: Use x-goog-api-key header for gemini auth

### DIFF
--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 )
 
 type GeminiProvider struct {
@@ -29,14 +28,7 @@ func NewGeminiProvider(apiKey, model, embedModel string) *GeminiProvider {
 }
 
 func (p *GeminiProvider) Chat(ctx context.Context, system, user string) (string, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/v1beta/models/%s:generateContent", p.baseURL, p.model))
-	if err != nil {
-		return "", fmt.Errorf("failed to parse URL: %w", err)
-	}
-	q := u.Query()
-	q.Set("key", p.apiKey)
-	u.RawQuery = q.Encode()
-	reqURL := u.String()
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:generateContent", p.baseURL, p.model)
 
 	// Combine system and user prompts for Gemini
 	fullPrompt := fmt.Sprintf("%s\n\n%s", system, user)
@@ -64,7 +56,7 @@ func (p *GeminiProvider) Chat(ctx context.Context, system, user string) (string,
 		} `json:"candidates"`
 	}
 
-	err = p.post(ctx, reqURL, payload, &res)
+	err := p.post(ctx, reqURL, payload, &res)
 	if err != nil {
 		return "", err
 	}
@@ -77,14 +69,7 @@ func (p *GeminiProvider) Chat(ctx context.Context, system, user string) (string,
 }
 
 func (p *GeminiProvider) CreateEmbedding(ctx context.Context, text string) ([]float32, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/v1beta/models/%s:embedContent", p.baseURL, p.embedModel))
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URL: %w", err)
-	}
-	q := u.Query()
-	q.Set("key", p.apiKey)
-	u.RawQuery = q.Encode()
-	reqURL := u.String()
+	reqURL := fmt.Sprintf("%s/v1beta/models/%s:embedContent", p.baseURL, p.embedModel)
 
 	payload := map[string]interface{}{
 		"content": map[string]interface{}{
@@ -100,7 +85,7 @@ func (p *GeminiProvider) CreateEmbedding(ctx context.Context, text string) ([]fl
 		} `json:"embedding"`
 	}
 
-	err = p.post(ctx, reqURL, payload, &res)
+	err := p.post(ctx, reqURL, payload, &res)
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +104,7 @@ func (p *GeminiProvider) post(ctx context.Context, url string, body interface{},
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", p.apiKey)
 
 	resp, err := p.client.Do(req)
 	if err != nil {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -17,8 +17,8 @@ func TestGeminiProvider_Chat(t *testing.T) {
 		if r.URL.Path != "/v1beta/models/gemini-1.5-flash:generateContent" {
 			t.Errorf("Unexpected path: %s", r.URL.Path)
 		}
-		if r.URL.Query().Get("key") != "test-api-key" {
-			t.Errorf("Unexpected API key: %s", r.URL.Query().Get("key"))
+		if r.Header.Get("x-goog-api-key") != "test-api-key" {
+			t.Errorf("Unexpected API key: %s", r.Header.Get("x-goog-api-key"))
 		}
 
 		// Validate request body
@@ -113,8 +113,8 @@ func TestGeminiProvider_CreateEmbedding(t *testing.T) {
 		if r.URL.Path != "/v1beta/models/text-embedding-004:embedContent" {
 			t.Errorf("Unexpected path: %s", r.URL.Path)
 		}
-		if r.URL.Query().Get("key") != "test-api-key" {
-			t.Errorf("Unexpected API key: %s", r.URL.Query().Get("key"))
+		if r.Header.Get("x-goog-api-key") != "test-api-key" {
+			t.Errorf("Unexpected API key: %s", r.Header.Get("x-goog-api-key"))
 		}
 
 		// Validate request body
@@ -176,13 +176,13 @@ func TestGeminiProvider_CreateEmbedding(t *testing.T) {
 	}
 }
 
-func TestGeminiProvider_URLEncoding(t *testing.T) {
-	// Test that API keys with special characters are properly URL-encoded
+func TestGeminiProvider_HeaderAuth_SpecialChars(t *testing.T) {
+	// Test that API keys with special characters are properly sent in header
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check that the API key is properly received (decoded by the server)
-		key := r.URL.Query().Get("key")
+		// Check that the API key is properly received in header
+		key := r.Header.Get("x-goog-api-key")
 		if key != "test+key&with=special%chars" {
-			t.Errorf("API key not properly encoded/decoded. Expected 'test+key&with=special%%chars', got: %s", key)
+			t.Errorf("API key header mismatch. Expected 'test+key&with=special%%chars', got: %s", key)
 		}
 
 		resp := struct {


### PR DESCRIPTION
Migrate Gemini API key from request body to header

- https://docs.cloud.google.com/docs/authentication/api-keys-use#go
- https://docs.cloud.google.com/docs/authentication/api-keys-best-practices
