### PR TITLE
feat: Implement granular CLI exit codes

### DIFF
--- a/cmd/archguard-e2e/main.go
+++ b/cmd/archguard-e2e/main.go
@@ -22,7 +22,7 @@ func main() {
 		}
 
 		mock.ChatFunc = func(ctx context.Context, system, user string) (string, error) {
-			if strings.Contains(user, testutil.MockViolationTrigger) {
+			if codeContextContainsTrigger(user, testutil.MockViolationTrigger) {
 				return `{"violation": true, "reasoning": "Mock violation: trigger found", "quoted_code": "` + testutil.MockViolationTrigger + `"}`, nil
 			}
 			return `{"violation": false, "reasoning": "Mock: no violation", "quoted_code": ""}`, nil
@@ -36,4 +36,19 @@ func main() {
 		os.Exit(int(exitCode))
 	}
 	os.Exit(int(cli.ExitSuccess))
+}
+
+func codeContextContainsTrigger(prompt, trigger string) bool {
+	start := strings.Index(prompt, "<code_context>")
+	if start == -1 {
+		return false
+	}
+	start += len("<code_context>")
+
+	endOffset := strings.Index(prompt[start:], "</code_context>")
+	if endOffset == -1 {
+		return false
+	}
+
+	return strings.Contains(prompt[start:start+endOffset], trigger)
 }

--- a/cmd/archguard-e2e/main.go
+++ b/cmd/archguard-e2e/main.go
@@ -45,10 +45,10 @@ func codeContextContainsTrigger(prompt, trigger string) bool {
 	}
 	start += len("<code_context>")
 
-	endOffset := strings.Index(prompt[start:], "</code_context>")
-	if endOffset == -1 {
+	endRelativeOffset := strings.Index(prompt[start:], "</code_context>")
+	if endRelativeOffset == -1 {
 		return false
 	}
 
-	return strings.Contains(prompt[start:start+endOffset], trigger)
+	return strings.Contains(prompt[start:start+endRelativeOffset], trigger)
 }

--- a/cmd/archguard-e2e/main.go
+++ b/cmd/archguard-e2e/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tgenz1213/archguard/internal/cli"
 	"github.com/tgenz1213/archguard/internal/config"
 	"github.com/tgenz1213/archguard/internal/llm"
+	"github.com/tgenz1213/archguard/internal/testutil"
 )
 
 func main() {
@@ -21,8 +22,8 @@ func main() {
 		}
 
 		mock.ChatFunc = func(ctx context.Context, system, user string) (string, error) {
-			if strings.Contains(user, "password") {
-				return `{"violation": true, "reasoning": "Mock violation: password found", "quoted_code": "password"}`, nil
+			if strings.Contains(user, testutil.MockViolationTrigger) {
+				return `{"violation": true, "reasoning": "Mock violation: trigger found", "quoted_code": "` + testutil.MockViolationTrigger + `"}`, nil
 			}
 			return `{"violation": false, "reasoning": "Mock: no violation", "quoted_code": ""}`, nil
 		}
@@ -30,8 +31,9 @@ func main() {
 		return mock
 	}
 
-	if err := cli.Execute(mockFactory); err != nil {
+	if exitCode, err := cli.Execute(mockFactory); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		os.Exit(int(exitCode))
 	}
+	os.Exit(int(cli.ExitSuccess))
 }

--- a/cmd/archguard-e2e/main_test.go
+++ b/cmd/archguard-e2e/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/tgenz1213/archguard/internal/llm"
+	"github.com/tgenz1213/archguard/internal/testutil"
+)
+
+func TestCodeContextContainsTrigger(t *testing.T) {
+	t.Run("matches when trigger appears in code context", func(t *testing.T) {
+		prompt := llm.GetAnalyzeDriftPrompt("ADR without trigger", "const s = \"password\";", "x.js")
+		if !codeContextContainsTrigger(prompt, testutil.MockViolationTrigger) {
+			t.Fatalf("expected trigger match inside code_context")
+		}
+	})
+
+	t.Run("does not match when trigger appears only in ADR content", func(t *testing.T) {
+		prompt := llm.GetAnalyzeDriftPrompt("Do not print passwords", "const s = \"token\";", "x.js")
+		if codeContextContainsTrigger(prompt, testutil.MockViolationTrigger) {
+			t.Fatalf("expected no trigger match when only ADR contains trigger")
+		}
+	})
+
+	t.Run("does not match when code context tags are missing", func(t *testing.T) {
+		if codeContextContainsTrigger("random prompt content", testutil.MockViolationTrigger) {
+			t.Fatalf("expected no trigger match without code_context tags")
+		}
+	})
+}

--- a/cmd/archguard/main.go
+++ b/cmd/archguard/main.go
@@ -8,8 +8,9 @@ import (
 )
 
 func main() {
-	if err := cli.Execute(nil); err != nil {
+	if exitCode, err := cli.Execute(nil); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		os.Exit(int(exitCode))
 	}
+	os.Exit(int(cli.ExitSuccess))
 }

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -2,6 +2,7 @@ package analysis_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/tgenz1213/archguard/internal/analysis"
@@ -85,6 +86,9 @@ func TestDriftDetection(t *testing.T) {
 	}
 	if err.Error() != "found 1 architectural violations" {
 		t.Fatalf("Expected 'found 1 architectural violations', got '%v'", err)
+	}
+	if !errors.Is(err, analysis.ErrDriftDetected) {
+		t.Fatalf("Expected error to match ErrDriftDetected, got '%v'", err)
 	}
 }
 

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -23,6 +24,22 @@ type Engine struct {
 	Debug    bool
 	CI       bool // CI-safe mode (Warn-Open behavior)
 	Cache    *cache.Cache
+}
+
+// ErrDriftDetected identifies analysis results that contain architectural violations.
+var ErrDriftDetected = errors.New("architectural drift detected")
+
+// DriftDetectedError reports the number of architectural violations found.
+type DriftDetectedError struct {
+	Count int
+}
+
+func (e *DriftDetectedError) Error() string {
+	return fmt.Sprintf("found %d architectural violations", e.Count)
+}
+
+func (e *DriftDetectedError) Is(target error) bool {
+	return target == ErrDriftDetected
 }
 
 // NewEngine initializes a new analysis engine with a local cache.
@@ -220,7 +237,7 @@ func (e *Engine) Run(ctx context.Context) error {
 	wg.Wait()
 
 	if violations > 0 {
-		return fmt.Errorf("found %d architectural violations", violations)
+		return &DriftDetectedError{Count: violations}
 	}
 
 	return nil

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,10 +2,10 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -305,13 +305,17 @@ scope: "[Optional: glob pattern, e.g., **/*.go]"
 // based on the provided flags and ADR index.
 func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args []string) (ExitCode, error) {
 	checkFlags := flag.NewFlagSet("check", flag.ContinueOnError)
-	checkFlags.SetOutput(io.Discard)
+	var flagParseOutput bytes.Buffer
+	checkFlags.SetOutput(&flagParseOutput)
 	staged := checkFlags.Bool("staged", false, "Scan staged files only")
 	all := checkFlags.Bool("all", false, "Scan all tracked files")
 	debug := checkFlags.Bool("debug", false, "Enable debug logging")
 	ci := checkFlags.Bool("ci", false, "Enable CI-safe mode (Warn-Open behavior)")
 
 	if err := checkFlags.Parse(args); err != nil {
+		if details := strings.TrimSpace(flagParseOutput.String()); details != "" {
+			return ExitUsage, fmt.Errorf("error parsing flags: %v\n%s", err, details)
+		}
 		return ExitUsage, fmt.Errorf("error parsing flags: %v", err)
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -368,7 +368,8 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 }
 
 func exitCodeForAnalysisError(err error) ExitCode {
-	if errors.Is(err, analysis.ErrDriftDetected) {
+	var driftErr *analysis.DriftDetectedError
+	if errors.As(err, &driftErr) {
 		return ExitDriftDetected
 	}
 	return ExitError

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -16,17 +16,28 @@ import (
 	"github.com/tgenz1213/archguard/internal/llm"
 )
 
+type ExitCode int
+
+const (
+	ExitSuccess       ExitCode = 0
+	ExitError         ExitCode = 1
+	ExitUsage         ExitCode = 2
+	ExitConfig        ExitCode = 3
+	ExitDriftDetected ExitCode = 4
+	ExitIndexError    ExitCode = 5
+)
+
 const defaultADRPath = "./docs/arch"
 const configFilename = "archguard.yaml"
 
 // Execute parses the command-line arguments, normalizes paths relative to the git root,
 // and routes execution to the appropriate command handler.
-func Execute(providerFactory func(*config.Config) llm.Provider) error {
+func Execute(providerFactory func(*config.Config) llm.Provider) (ExitCode, error) {
 	fmt.Println("ArchGuard - Architectural Drift Detector")
 
 	repoRoot, err := git.GetRepoRoot()
 	if err != nil {
-		return fmt.Errorf("%v (ArchGuard must be run inside a git repository)", err)
+		return ExitError, fmt.Errorf("%v (ArchGuard must be run inside a git repository)", err)
 	}
 
 	cwd, _ := os.Getwd()
@@ -47,7 +58,7 @@ func Execute(providerFactory func(*config.Config) llm.Provider) error {
 		}
 
 		if err := os.Chdir(repoRoot); err != nil {
-			return fmt.Errorf("error changing to git root: %v", err)
+			return ExitError, fmt.Errorf("error changing to git root: %v", err)
 		}
 	}
 
@@ -57,16 +68,19 @@ func Execute(providerFactory func(*config.Config) llm.Provider) error {
 
 	if len(os.Args) < 2 {
 		printUsage()
-		return fmt.Errorf("no command provided")
+		return ExitUsage, fmt.Errorf("no command provided")
 	}
 
 	if os.Args[1] == "init" {
-		return runInit()
+		if err := runInit(); err != nil {
+			return ExitError, err
+		}
+		return ExitSuccess, nil
 	}
 
 	cfg, err := config.LoadConfig(configFilename)
 	if err != nil {
-		return fmt.Errorf("error loading config: %v", err)
+		return ExitConfig, fmt.Errorf("error loading config: %v", err)
 	}
 
 	indexFile := ".archguard/index.json"
@@ -94,7 +108,7 @@ func Execute(providerFactory func(*config.Config) llm.Provider) error {
 			}
 			provider = llm.NewGeminiProvider(apiKey, cfg.LLM.Model, cfg.VectorStore.Model)
 		default:
-			return fmt.Errorf("unknown provider: %s", cfg.LLM.Provider)
+			return ExitConfig, fmt.Errorf("unknown provider: %s", cfg.LLM.Provider)
 		}
 	}
 
@@ -105,7 +119,7 @@ func Execute(providerFactory func(*config.Config) llm.Provider) error {
 		return runIndex(cfg, provider, indexFile)
 	default:
 		printUsage()
-		return fmt.Errorf("unknown command: %s", os.Args[1])
+		return ExitUsage, fmt.Errorf("unknown command: %s", os.Args[1])
 	}
 }
 
@@ -287,7 +301,7 @@ scope: "[Optional: glob pattern, e.g., **/*.go]"
 
 // runCheck executes the architectural drift analysis against a set of files
 // based on the provided flags and ADR index.
-func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args []string) error {
+func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args []string) (ExitCode, error) {
 	checkFlags := flag.NewFlagSet("check", flag.ExitOnError)
 	staged := checkFlags.Bool("staged", false, "Scan staged files only")
 	all := checkFlags.Bool("all", false, "Scan all tracked files")
@@ -295,7 +309,7 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 	ci := checkFlags.Bool("ci", false, "Enable CI-safe mode (Warn-Open behavior)")
 
 	if err := checkFlags.Parse(args); err != nil {
-		return fmt.Errorf("error parsing flags: %v", err)
+		return ExitUsage, fmt.Errorf("error parsing flags: %v", err)
 	}
 
 	files := checkFlags.Args()
@@ -303,11 +317,11 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 	store := index.NewStore()
 	currentHash, err := store.CalculateHash(cfg.Analysis.ADRPath, cfg.VectorStore.Model)
 	if err != nil {
-		return fmt.Errorf("failed to calculate ADR hash: %v", err)
+		return ExitError, fmt.Errorf("failed to calculate ADR hash: %v", err)
 	}
 
 	if err := store.Load(indexFile, cfg.VectorStore.Model, cfg.VectorStore.EmbeddingDim, currentHash); err != nil {
-		return fmt.Errorf("index mismatch or load failed (run 'archguard index' to rebuild): %v", err)
+		return ExitIndexError, fmt.Errorf("index mismatch or load failed (run 'archguard index' to rebuild): %v", err)
 	}
 
 	var contentProvider analysis.ContentProvider
@@ -332,23 +346,23 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 
 	engine := analysis.NewEngine(cfg, store, provider, contentProvider, *debug, *ci)
 	if err := engine.Run(context.Background()); err != nil {
-		return fmt.Errorf("analysis failed: %v", err)
+		return ExitDriftDetected, fmt.Errorf("analysis failed: %v", err)
 	}
 	fmt.Println("No architectural violations found.")
-	return nil
+	return ExitSuccess, nil
 }
 
 // runIndex scans the ADR directory and builds a vector index for subsequent drift analysis.
-func runIndex(cfg *config.Config, provider llm.Provider, indexFile string) error {
+func runIndex(cfg *config.Config, provider llm.Provider, indexFile string) (ExitCode, error) {
 	store := index.NewStore()
 	if err := store.BuildIndex(context.Background(), cfg.Analysis.ADRPath, cfg.VectorStore.Model, provider, cfg.Analysis.AcceptedStatuses); err != nil {
-		return fmt.Errorf("indexing failed: %v", err)
+		return ExitIndexError, fmt.Errorf("indexing failed: %v", err)
 	}
 	if err := store.Save(indexFile); err != nil {
-		return fmt.Errorf("failed to save index: %v", err)
+		return ExitIndexError, fmt.Errorf("failed to save index: %v", err)
 	}
 	fmt.Println("ADR Index updated successfully.")
-	return nil
+	return ExitSuccess, nil
 }
 
 func printUsage() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -71,11 +71,17 @@ func Execute(providerFactory func(*config.Config) llm.Provider) (ExitCode, error
 		return ExitUsage, fmt.Errorf("no command provided")
 	}
 
-	if os.Args[1] == "init" {
+	command := os.Args[1]
+	switch command {
+	case "init":
 		if err := runInit(); err != nil {
 			return ExitError, err
 		}
 		return ExitSuccess, nil
+	case "check", "index":
+	default:
+		printUsage()
+		return ExitUsage, fmt.Errorf("unknown command: %s", command)
 	}
 
 	cfg, err := config.LoadConfig(configFilename)
@@ -112,15 +118,14 @@ func Execute(providerFactory func(*config.Config) llm.Provider) (ExitCode, error
 		}
 	}
 
-	switch os.Args[1] {
+	switch command {
 	case "check":
 		return runCheck(cfg, provider, indexFile, os.Args[2:])
 	case "index":
 		return runIndex(cfg, provider, indexFile)
-	default:
-		printUsage()
-		return ExitUsage, fmt.Errorf("unknown command: %s", os.Args[1])
 	}
+
+	return ExitError, fmt.Errorf("unreachable command: %s", command)
 }
 
 // runInit initializes a new ArchGuard project by prompting the user for configuration

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -323,6 +323,13 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 		return ExitError, fmt.Errorf("failed to calculate ADR hash: %v", err)
 	}
 
+	if _, err := os.Stat(indexFile); err != nil {
+		if os.IsNotExist(err) {
+			return ExitIndexError, fmt.Errorf("index not found (run 'archguard index' to build it): %v", err)
+		}
+		return ExitError, fmt.Errorf("failed to access index file: %v", err)
+	}
+
 	if err := store.Load(indexFile, cfg.VectorStore.Model, cfg.VectorStore.EmbeddingDim, currentHash); err != nil {
 		return ExitIndexError, fmt.Errorf("index mismatch or load failed (run 'archguard index' to rebuild): %v", err)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -360,10 +361,17 @@ func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args 
 
 	engine := analysis.NewEngine(cfg, store, provider, contentProvider, *debug, *ci)
 	if err := engine.Run(context.Background()); err != nil {
-		return ExitDriftDetected, fmt.Errorf("analysis failed: %v", err)
+		return exitCodeForAnalysisError(err), fmt.Errorf("analysis failed: %v", err)
 	}
 	fmt.Println("No architectural violations found.")
 	return ExitSuccess, nil
+}
+
+func exitCodeForAnalysisError(err error) ExitCode {
+	if errors.Is(err, analysis.ErrDriftDetected) {
+		return ExitDriftDetected
+	}
+	return ExitError
 }
 
 // runIndex scans the ADR directory and builds a vector index for subsequent drift analysis.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -303,7 +304,8 @@ scope: "[Optional: glob pattern, e.g., **/*.go]"
 // runCheck executes the architectural drift analysis against a set of files
 // based on the provided flags and ADR index.
 func runCheck(cfg *config.Config, provider llm.Provider, indexFile string, args []string) (ExitCode, error) {
-	checkFlags := flag.NewFlagSet("check", flag.ExitOnError)
+	checkFlags := flag.NewFlagSet("check", flag.ContinueOnError)
+	checkFlags.SetOutput(io.Discard)
 	staged := checkFlags.Bool("staged", false, "Scan staged files only")
 	all := checkFlags.Bool("all", false, "Scan all tracked files")
 	debug := checkFlags.Bool("debug", false, "Enable debug logging")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -118,14 +118,10 @@ func Execute(providerFactory func(*config.Config) llm.Provider) (ExitCode, error
 		}
 	}
 
-	switch command {
-	case "check":
+	if command == "check" {
 		return runCheck(cfg, provider, indexFile, os.Args[2:])
-	case "index":
-		return runIndex(cfg, provider, indexFile)
 	}
-
-	return ExitError, fmt.Errorf("unreachable command: %s", command)
+	return runIndex(cfg, provider, indexFile)
 }
 
 // runInit initializes a new ArchGuard project by prompting the user for configuration

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,13 @@ import (
 )
 
 func TestExitCodeForAnalysisError(t *testing.T) {
+	t.Run("returns drift exit code for direct drift detection errors", func(t *testing.T) {
+		err := &analysis.DriftDetectedError{Count: 2}
+		if got := exitCodeForAnalysisError(err); got != ExitDriftDetected {
+			t.Fatalf("expected %d, got %d", ExitDriftDetected, got)
+		}
+	})
+
 	t.Run("returns drift exit code for drift detection errors", func(t *testing.T) {
 		err := fmt.Errorf("wrapped: %w", &analysis.DriftDetectedError{Count: 2})
 		if got := exitCodeForAnalysisError(err); got != ExitDriftDetected {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -16,7 +16,7 @@ func TestExitCodeForAnalysisError(t *testing.T) {
 		}
 	})
 
-	t.Run("returns drift exit code for drift detection errors", func(t *testing.T) {
+	t.Run("returns drift exit code for wrapped drift detection errors", func(t *testing.T) {
 		err := fmt.Errorf("wrapped: %w", &analysis.DriftDetectedError{Count: 2})
 		if got := exitCodeForAnalysisError(err); got != ExitDriftDetected {
 			t.Fatalf("expected %d, got %d", ExitDriftDetected, got)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/tgenz1213/archguard/internal/analysis"
+)
+
+func TestExitCodeForAnalysisError(t *testing.T) {
+	t.Run("returns drift exit code for drift detection errors", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", &analysis.DriftDetectedError{Count: 2})
+		if got := exitCodeForAnalysisError(err); got != ExitDriftDetected {
+			t.Fatalf("expected %d, got %d", ExitDriftDetected, got)
+		}
+	})
+
+	t.Run("returns generic error exit code for operational errors", func(t *testing.T) {
+		err := errors.New("git content provider failure")
+		if got := exitCodeForAnalysisError(err); got != ExitError {
+			t.Fatalf("expected %d, got %d", ExitError, got)
+		}
+	})
+}

--- a/internal/testutil/mock.go
+++ b/internal/testutil/mock.go
@@ -1,0 +1,7 @@
+package testutil
+
+const (
+	// MockViolationTrigger is the specific string that the mock LLM provider
+	// looks for to simulate an architectural violation during E2E testing.
+	MockViolationTrigger = "password"
+)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -5,32 +5,33 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/tgenz1213/archguard/internal/cli"
+	"github.com/tgenz1213/archguard/internal/testutil"
 )
 
-const (
-	fixtureContent = `
-function sensitiveData() {
-    console.log("password: 123");
+const fixtureFilename = "sensitive.js"
+
+func getBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "e2e_archguard.exe"
+	}
+	return "e2e_archguard"
 }
-`
-	fixtureFilename = "sensitive.js"
-	binaryName      = "e2e_archguard.exe"
-)
 
 // TestE2E_ScanJS verifies that the CLI correctly identifies violations in a JS file
 // and passes when the file is removed.
 func TestE2E_ScanJS(t *testing.T) {
-	wd, err := os.Getwd()
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatalf("Failed to get working directory: %v", err)
+		t.Fatalf("Failed to get module root: %v", err)
 	}
-
-	sourceRoot := filepath.Dir(wd)
-	if filepath.Base(wd) != "test" {
-		sourceRoot = wd
-	}
+	sourceRoot := strings.TrimSpace(string(out))
 
 	tempDir := t.TempDir()
 
@@ -59,6 +60,7 @@ analysis:
 		t.Fatalf("Failed to create .env: %v", err)
 	}
 
+	binaryName := getBinaryName()
 	t.Log("Building archguard binary for E2E test...")
 	binaryPath := filepath.Join(tempDir, binaryName)
 	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/archguard-e2e")
@@ -68,6 +70,12 @@ analysis:
 	}
 
 	fixturePath := filepath.Join(tempDir, fixtureFilename)
+
+	fixtureContent := fmt.Sprintf(`
+function sensitiveData() {
+    console.log("%s: 123");
+}
+`, testutil.MockViolationTrigger)
 
 	if err := os.WriteFile(fixturePath, []byte(fixtureContent), 0644); err != nil {
 		t.Fatalf("Failed to create fixture: %v", err)
@@ -94,29 +102,64 @@ Do not print passwords or secrets to console.log.`
 	}
 
 	t.Log("Indexing ADRs for E2E test...")
-	indexCmd := exec.Command(binaryPath, "index")
-	indexCmd.Dir = tempDir
-	indexCmd.Env = append(os.Environ(), "ARCHGUARD_API_KEY=mock_key")
-	out, err := indexCmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to index for E2E test: %v\nOutput: %s", err, string(out))
-	}
-	t.Logf("Index output: %s", string(out))
+	runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
+
+	t.Run("Index command fails on invalid ADR path", func(t *testing.T) {
+		// Change config to point to a non-existent path
+		badConfigContent := `
+version: "1"
+llm:
+  provider: "ollama"
+vector_store:
+  provider: "ollama"
+  embedding_dim: 768
+analysis:
+  adr_path: "./does_not_exist"
+  accepted_statuses: ["Accepted", "Active"]
+`
+		err := os.WriteFile(filepath.Join(tempDir, "archguard.yaml"), []byte(badConfigContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to write bad config: %v", err)
+		}
+
+		runIndexCmd(t, tempDir, binaryPath, int(cli.ExitIndexError))
+
+		// Restore valid config
+		err = os.WriteFile(filepath.Join(tempDir, "archguard.yaml"), []byte(configContent), 0644)
+		if err != nil {
+			t.Fatalf("Failed to restore config: %v", err)
+		}
+	})
+
+	t.Run("Fails to check with corrupt index", func(t *testing.T) {
+		indexPath := filepath.Join(tempDir, ".archguard", "index.json")
+		if err := os.MkdirAll(filepath.Dir(indexPath), 0755); err != nil {
+			t.Fatalf("Failed to create archguard dir: %v", err)
+		}
+		if err := os.WriteFile(indexPath, []byte("{corrupt json"), 0644); err != nil {
+			t.Fatalf("Failed to corrupt index: %v", err)
+		}
+
+		runCheck(t, tempDir, binaryPath, fixtureFilename, int(cli.ExitIndexError))
+
+		// Re-run index to fix it for subsequent tests
+		runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
+	})
 
 	t.Run("Detects violation in JS file", func(t *testing.T) {
-		runCheck(t, tempDir, binaryPath, fixtureFilename, true)
+		runCheck(t, tempDir, binaryPath, fixtureFilename, int(cli.ExitDriftDetected))
 	})
 
 	t.Run("Passes after fixture removal", func(t *testing.T) {
 		if err := os.Remove(fixturePath); err != nil {
 			t.Fatalf("Failed to remove fixture: %v", err)
 		}
-		runCheck(t, tempDir, binaryPath, fixtureFilename, false)
+		runCheck(t, tempDir, binaryPath, fixtureFilename, int(cli.ExitSuccess))
 	})
 }
 
 // runCheck executes the archguard check command.
-func runCheck(t *testing.T, dir, binaryPath, target string, expectFail bool) {
+func runCheck(t *testing.T, dir, binaryPath, target string, expectedExitCode int) {
 	t.Helper()
 
 	const maxRetries = 3
@@ -144,17 +187,10 @@ func runCheck(t *testing.T, dir, binaryPath, target string, expectFail bool) {
 			}
 		}
 
-		if expectFail {
-			if exitCode != 0 {
-				return
-			}
-			lastErr = fmt.Errorf("expected violation failure, but got success or unrelated error. Output: %s", outputStr)
-		} else {
-			if exitCode == 0 {
-				return
-			}
-			lastErr = fmt.Errorf("expected success, but got error: %v. Output: %s", err, outputStr)
+		if exitCode == expectedExitCode {
+			return
 		}
+		lastErr = fmt.Errorf("expected exit code %d, but got %d. Output: %s", expectedExitCode, exitCode, outputStr)
 
 		if i < maxRetries-1 {
 			t.Logf("Retry %d/%d", i+1, maxRetries)
@@ -163,4 +199,30 @@ func runCheck(t *testing.T, dir, binaryPath, target string, expectFail bool) {
 	}
 
 	t.Fatalf("runCheck failed after %d retries: %v", maxRetries, lastErr)
+}
+
+// runIndexCmd executes the archguard index command and checks the expected exit code.
+func runIndexCmd(t *testing.T, dir, binaryPath string, expectedExitCode int) {
+	t.Helper()
+
+	cmd := exec.Command(binaryPath, "index")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "ARCHGUARD_API_KEY=mock_key")
+
+	output, err := cmd.CombinedOutput()
+	outputStr := string(output)
+
+	exitCode := 0
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			t.Fatalf("Index binary failed to execute: %v", err)
+		}
+	}
+
+	if exitCode != expectedExitCode {
+		t.Fatalf("expected index exit code %d, but got %d. Output: %s", expectedExitCode, exitCode, outputStr)
+	}
+	t.Logf("Index output: %s", outputStr)
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -150,14 +150,13 @@ analysis:
 		if err != nil {
 			t.Fatalf("Failed to write bad config: %v", err)
 		}
+		defer func() {
+			if err := os.WriteFile(filepath.Join(tempDir, "archguard.yaml"), []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to restore config: %v", err)
+			}
+		}()
 
 		runIndexCmd(t, tempDir, binaryPath, int(cli.ExitIndexError))
-
-		// Restore valid config
-		err = os.WriteFile(filepath.Join(tempDir, "archguard.yaml"), []byte(configContent), 0644)
-		if err != nil {
-			t.Fatalf("Failed to restore config: %v", err)
-		}
 	})
 
 	t.Run("Fails to check with corrupt index", func(t *testing.T) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -187,10 +187,10 @@ analysis:
 			t.Fatalf("Failed to corrupt index: %v", err)
 		}
 
-		runCheck(t, tempDir, binaryPath, fixtureFilename, int(cli.ExitIndexError))
+		// Re-run index to fix it for subsequent tests, even if runCheck aborts this subtest.
+		defer runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
 
-		// Re-run index to fix it for subsequent tests
-		runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
+		runCheck(t, tempDir, binaryPath, fixtureFilename, int(cli.ExitIndexError))
 	})
 
 	t.Run("Detects violation in JS file", func(t *testing.T) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -104,6 +104,35 @@ Do not print passwords or secrets to console.log.`
 	t.Log("Indexing ADRs for E2E test...")
 	runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
 
+	t.Run("Unknown command returns usage exit code without config", func(t *testing.T) {
+		configPath := filepath.Join(tempDir, "archguard.yaml")
+		if err := os.Remove(configPath); err != nil {
+			t.Fatalf("Failed to remove config: %v", err)
+		}
+		defer func() {
+			if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to restore config: %v", err)
+			}
+		}()
+
+		cmd := exec.Command(binaryPath, "typo")
+		cmd.Dir = tempDir
+		cmd.Env = append(os.Environ(), "ARCHGUARD_API_KEY=mock_key")
+
+		_, err := cmd.CombinedOutput()
+		exitCode := 0
+		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				exitCode = exitError.ExitCode()
+			} else {
+				t.Fatalf("Binary failed to execute: %v", err)
+			}
+		}
+		if exitCode != int(cli.ExitUsage) {
+			t.Fatalf("expected usage exit code %d, got %d", cli.ExitUsage, exitCode)
+		}
+	})
+
 	t.Run("Index command fails on invalid ADR path", func(t *testing.T) {
 		// Change config to point to a non-existent path
 		badConfigContent := `

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -133,6 +133,25 @@ Do not print passwords or secrets to console.log.`
 		}
 	})
 
+	t.Run("Check command invalid flag returns usage exit code", func(t *testing.T) {
+		cmd := exec.Command(binaryPath, "check", "--not-a-real-flag")
+		cmd.Dir = tempDir
+		cmd.Env = append(os.Environ(), "ARCHGUARD_API_KEY=mock_key")
+
+		_, err := cmd.CombinedOutput()
+		exitCode := 0
+		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				exitCode = exitError.ExitCode()
+			} else {
+				t.Fatalf("Binary failed to execute: %v", err)
+			}
+		}
+		if exitCode != int(cli.ExitUsage) {
+			t.Fatalf("expected usage exit code %d, got %d", cli.ExitUsage, exitCode)
+		}
+	})
+
 	t.Run("Index command fails on invalid ADR path", func(t *testing.T) {
 		// Change config to point to a non-existent path
 		badConfigContent := `


### PR DESCRIPTION
## Description

This PR hardens the ArchGuard E2E test suite and CLI error handling, specifically focusing on cross-platform reliability, error code validation, and mock consistency.

### Changes Made

**CLI Error Handling**
* Updated the `runIndex` command in `internal/cli/cli.go` to correctly return `ExitIndexError` (exit code `5`) rather than the generic `ExitError` (exit code `1`) when the index generation or save process fails. 

**E2E Test Stability & Refactoring**
* **Strict Exit Codes**: Upgraded `test/e2e_test.go` helpers (`runCheck` and the newly introduced `runIndexCmd`) to assert explicitly against specific, expected exit codes from the `cli` package (e.g., `ExitDriftDetected`, `ExitSuccess`), rather than doing generic zero vs non-zero checks.
* **Corrupt Index Validation**: Added a new test case targeting the CLI's resilience against corrupted indexes, ensuring that a malformed `.archguard/index.json` correctly triggers the `ExitIndexError` code.
* **Module Root Discovery**: Removed brittle, relative directory logic used during the `go build` setup phase. Replaced it with `go list -m -f {{.Dir}}` to predictably find the absolute module root regardless of how the tests are invoked.
* **Cross-Platform Compatibility**: Replaced the hardcoded `.exe` string for the built artifact with a dynamic `runtime.GOOS` check, guaranteeing that tests successfully run across Windows, macOS, and Linux environments.

**Mock Centralization**
* Created a shared test fixture package `internal/testutil` which holds the `MockViolationTrigger` constant.
* Synced both the `cmd/archguard-e2e` mock LLM provider and the dynamic `fixtureContent` in the test suite to use this central constant. This prevents "split-brain" bugs where changing an ADR violation string in the test could cause it to silently pass because the mock binary was still looking for the old trigger.