### PR TITLE
perf: optimize vector indexing and provider concurrency

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -50,7 +50,7 @@ func TestDriftDetection(t *testing.T) {
 	}
 
 	// 2. Setup Store with one ADR
-	store := index.NewLocalStore()
+	store := index.NewLocalStore(5)
 	store.ADRs = []index.ADR{
 		{
 			ID:        "0001",
@@ -105,7 +105,7 @@ func TestCustomSystemPrompt(t *testing.T) {
 	}
 
 	// 2. Setup Store with one ADR
-	store := index.NewLocalStore()
+	store := index.NewLocalStore(5)
 	store.ADRs = []index.ADR{
 		{
 			ID:        "0001",

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -230,6 +230,7 @@ vector_store:
   embedding_dim: 768
   similarity_threshold: 0.75
   connection_string: ""
+  embedding_concurrency: 5
 
 analysis:
   adr_path: "%s"
@@ -426,7 +427,7 @@ func runIndex(ctx context.Context, cfg *config.Config, provider llm.Provider, in
 	}
 	adrProvider := index.NewCompositeProvider(providers...)
 
-	if err := store.BuildIndex(ctx, cfg.VectorStore.Model, provider, adrProvider); err != nil {
+	if err := store.BuildIndex(ctx, cfg.VectorStore.Model, cfg.VectorStore.EmbeddingDim, provider, adrProvider); err != nil {
 		return ExitIndexError, fmt.Errorf("failed to build index: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,11 +26,12 @@ type LLMConfig struct {
 }
 
 type VectorStore struct {
-	Provider            string  `yaml:"provider"`
-	Model               string  `yaml:"model"`
-	EmbeddingDim        int     `yaml:"embedding_dim"`
-	SimilarityThreshold float64 `yaml:"similarity_threshold"`
-	ConnectionString    string  `yaml:"connection_string"`
+	Provider             string  `yaml:"provider"`
+	Model                string  `yaml:"model"`
+	EmbeddingDim         int     `yaml:"embedding_dim"`
+	SimilarityThreshold  float64 `yaml:"similarity_threshold"`
+	ConnectionString     string  `yaml:"connection_string"`
+	EmbeddingConcurrency int     `yaml:"embedding_concurrency"`
 }
 
 type Confluence struct {
@@ -62,6 +63,10 @@ func LoadConfig(path string) (*Config, error) {
 
 	if envDBURL := os.Getenv("ARCHGUARD_DB_URL"); envDBURL != "" {
 		cfg.VectorStore.ConnectionString = envDBURL
+	}
+
+	if cfg.VectorStore.EmbeddingConcurrency <= 0 {
+		cfg.VectorStore.EmbeddingConcurrency = 5
 	}
 
 	return &cfg, nil

--- a/internal/index/pgvector.go
+++ b/internal/index/pgvector.go
@@ -18,10 +18,11 @@ type PgStore struct {
 	pool             *pgxpool.Pool
 	connectionString string
 	projectName      string
+	concurrency      int
 }
 
 // NewPgStore initializes a new PgStore connected to the given database URL.
-func NewPgStore(connStr string, projectName string) (*PgStore, error) {
+func NewPgStore(connStr string, projectName string, concurrency int) (*PgStore, error) {
 	ctx := context.Background()
 
 	// Ensure the vector extension exists BEFORE setting up the pool
@@ -53,6 +54,7 @@ func NewPgStore(connStr string, projectName string) (*PgStore, error) {
 		pool:             pool,
 		connectionString: connStr,
 		projectName:      projectName,
+		concurrency:      concurrency,
 	}, nil
 }
 
@@ -75,7 +77,8 @@ func (s *PgStore) Load(path, modelName string, dim int, currentHash string) erro
 			content TEXT,
 			embedding vector(%d),
 			UNIQUE (project_name, rel_path)
-		)
+		);
+		CREATE INDEX IF NOT EXISTS archguard_adrs_embedding_idx ON archguard_adrs USING hnsw (embedding vector_cosine_ops);
 	`, dim)
 
 	_, err := s.pool.Exec(ctx, query)
@@ -88,63 +91,137 @@ func (s *PgStore) Save(path string) error {
 }
 
 // BuildIndex parses the ADRs, generates embeddings, and inserts them into the database.
-func (s *PgStore) BuildIndex(ctx context.Context, modelName string, provider llm.Provider, adrProvider Provider) error {
+func (s *PgStore) BuildIndex(ctx context.Context, modelName string, dim int, provider llm.Provider, adrProvider Provider) error {
 	validADRs, err := adrProvider.GetADRs(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Found %d valid ADRs. Inserting into pgvector...\n", len(validADRs))
+	// Fetch existing ADRs from database for this project
+	rows, err := s.pool.Query(ctx, "SELECT rel_path, title, status, content FROM archguard_adrs WHERE project_name = $1", s.projectName)
+	if err != nil {
+		return fmt.Errorf("failed to query existing ADRs: %w", err)
+	}
+	defer rows.Close()
 
-	// Delete only the ADRs for this specific project
-	if _, err := s.pool.Exec(ctx, "DELETE FROM archguard_adrs WHERE project_name = $1", s.projectName); err != nil {
-		return fmt.Errorf("failed to clear old ADRs for project %s: %w", s.projectName, err)
+	existingMap := make(map[string]ADR)
+	for rows.Next() {
+		var relPath, title, status, content string
+		if err := rows.Scan(&relPath, &title, &status, &content); err != nil {
+			continue
+		}
+		existingMap[relPath] = ADR{
+			Title:   title,
+			Status:  status,
+			Content: content,
+		}
 	}
 
-	type result struct {
-		index     int
-		embedding []float32
-		err       error
-	}
-	results := make(chan result, len(validADRs))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 5)
-
-	for i := range validADRs {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
-			emb, err := provider.CreateEmbedding(ctx, textToEmbed)
-			results <- result{index: i, embedding: emb, err: err}
-		}(i)
+	var adrsToEmbed []int
+	for i, valid := range validADRs {
+		existing, ok := existingMap[valid.RelPath]
+		if ok && existing.Content == valid.Content && existing.Title == valid.Title && existing.Status == valid.Status {
+			// Already embedded and unchanged
+		} else {
+			adrsToEmbed = append(adrsToEmbed, i)
+		}
 	}
 
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
+	fmt.Printf("Found %d valid ADRs. Generating embeddings for %d new/modified ADRs...\n", len(validADRs), len(adrsToEmbed))
 
-	for res := range results {
-		if res.err != nil {
-			return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
+	if len(adrsToEmbed) > 0 {
+		type result struct {
+			index     int
+			embedding []float32
+			err       error
+		}
+		results := make(chan result, len(adrsToEmbed))
+		var wg sync.WaitGroup
+
+		concurrency := s.concurrency
+		if concurrency <= 0 {
+			concurrency = 5
+		}
+		sem := make(chan struct{}, concurrency)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		for _, idx := range adrsToEmbed {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
+				emb, err := provider.CreateEmbedding(ctx, textToEmbed)
+				results <- result{index: i, embedding: emb, err: err}
+			}(idx)
 		}
 
-		vec := pgvector.NewVector(res.embedding)
-		_, err := s.pool.Exec(ctx, `
-			INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
-			VALUES ($1, $2, $3, $4, $5, $6)`,
-			s.projectName, validADRs[res.index].RelPath, validADRs[res.index].Title, validADRs[res.index].Status, validADRs[res.index].Content, vec,
-		)
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		for res := range results {
+			if res.err != nil {
+				cancel() // immediately cancel remaining API requests
+				return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
+			}
+
+			vec := pgvector.NewVector(res.embedding)
+			_, err := s.pool.Exec(ctx, `
+				INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
+				VALUES ($1, $2, $3, $4, $5, $6)
+				ON CONFLICT (project_name, rel_path) DO UPDATE SET
+					title = EXCLUDED.title,
+					status = EXCLUDED.status,
+					content = EXCLUDED.content,
+					embedding = EXCLUDED.embedding
+			`, s.projectName, validADRs[res.index].RelPath, validADRs[res.index].Title, validADRs[res.index].Status, validADRs[res.index].Content, vec)
+			if err != nil {
+				return fmt.Errorf("failed to upsert ADR %s: %w", validADRs[res.index].RelPath, err)
+			}
+			fmt.Printf(".")
+		}
+		fmt.Println()
+	}
+
+	// Delete missing ADRs
+	validMap := make(map[string]bool)
+	for _, valid := range validADRs {
+		validMap[valid.RelPath] = true
+	}
+
+	var toDelete []string
+	for relPath := range existingMap {
+		if !validMap[relPath] {
+			toDelete = append(toDelete, relPath)
+		}
+	}
+
+	if len(toDelete) > 0 {
+		fmt.Printf("Deleting %d removed ADRs from database...\n", len(toDelete))
+		for _, relPath := range toDelete {
+			_, err := s.pool.Exec(ctx, "DELETE FROM archguard_adrs WHERE project_name = $1 AND rel_path = $2", s.projectName, relPath)
+			if err != nil {
+				return fmt.Errorf("failed to delete ADR %s: %w", relPath, err)
+			}
+		}
+	}
+
+	// Conditional HNSW maintenance routine
+	modifiedCount := len(adrsToEmbed) + len(toDelete)
+	totalCount := len(validADRs) + len(toDelete)
+	if totalCount > 0 && float64(modifiedCount)/float64(totalCount) >= 0.20 {
+		fmt.Println("Modifications exceeded 20% threshold. Rebuilding HNSW index...")
+		_, err := s.pool.Exec(ctx, "REINDEX INDEX archguard_adrs_embedding_idx")
 		if err != nil {
-			return fmt.Errorf("failed to insert ADR %s: %w", validADRs[res.index].RelPath, err)
+			fmt.Printf("Warning: failed to reindex HNSW graph: %v\n", err)
 		}
-		fmt.Printf(".")
 	}
-	fmt.Println()
 
 	return nil
 }

--- a/internal/index/pgvector_integration_test.go
+++ b/internal/index/pgvector_integration_test.go
@@ -53,7 +53,7 @@ func TestPgStore_Integration(t *testing.T) {
 	require.NoError(t, err)
 
 	// 2. Initialize PgStore
-	store, err := index.NewPgStore(connStr, "integration_test_project")
+	store, err := index.NewPgStore(connStr, "integration_test_project", 5)
 	require.NoError(t, err)
 
 	// 3. Load Store
@@ -85,13 +85,13 @@ Test Content`
 		},
 	}
 	localProvider := index.NewLocalProvider(tmpDir, []string{"Accepted"})
-	err = store.BuildIndex(ctx, "test-model", provider, localProvider)
+	err = store.BuildIndex(ctx, "test-model", 3, provider, localProvider)
 	require.NoError(t, err)
 
 	// Insert into a second project to test isolation
-	storeOther, err := index.NewPgStore(connStr, "other_project")
+	storeOther, err := index.NewPgStore(connStr, "other_project", 5)
 	require.NoError(t, err)
-	err = storeOther.BuildIndex(ctx, "test-model", provider, localProvider)
+	err = storeOther.BuildIndex(ctx, "test-model", 3, provider, localProvider)
 	require.NoError(t, err)
 
 	// 6. Search

--- a/internal/index/provider.go
+++ b/internal/index/provider.go
@@ -3,6 +3,7 @@ package index
 import (
 	"context"
 	"fmt"
+	"sync"
 )
 
 // Provider defines how ArchGuard fetches ADR documents.
@@ -23,21 +24,32 @@ func NewCompositeProvider(providers ...Provider) *CompositeProvider {
 	}
 }
 
-// GetADRs fetches ADRs from all configured providers and aggregates them into a single slice.
+// GetADRs fetches ADRs from all configured providers concurrently and aggregates them into a single slice.
 func (c *CompositeProvider) GetADRs(ctx context.Context) ([]ADR, error) {
 	var allADRs []ADR
 	var errs []error
+	var mu sync.Mutex
+	var wg sync.WaitGroup
 
 	for _, p := range c.providers {
-		adrs, err := p.GetADRs(ctx)
-		if err != nil {
-			// Do not crash the entire run if one remote provider drops connection.
-			fmt.Printf("Warning: failed to fetch ADRs from a provider: %v\n", err)
-			errs = append(errs, err)
-			continue
-		}
-		allADRs = append(allADRs, adrs...)
+		wg.Add(1)
+		go func(p Provider) {
+			defer wg.Done()
+			adrs, err := p.GetADRs(ctx)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				// Do not crash the entire run if one remote provider drops connection.
+				fmt.Printf("Warning: failed to fetch ADRs from a provider: %v\n", err)
+				errs = append(errs, err)
+				return
+			}
+			allADRs = append(allADRs, adrs...)
+		}(p)
 	}
+	wg.Wait()
 
 	// If every single provider failed, then we should return an error.
 	if len(c.providers) > 0 && len(errs) == len(c.providers) {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -20,31 +20,33 @@ type VectorStore interface {
 	CalculateHash(adrs []ADR, modelName string) (string, error)
 	Load(path, modelName string, dim int, currentHash string) error
 	Save(path string) error
-	BuildIndex(ctx context.Context, modelName string, provider llm.Provider, adrProvider Provider) error
+	BuildIndex(ctx context.Context, modelName string, dim int, provider llm.Provider, adrProvider Provider) error
 	Search(queryEmbedding []float32, threshold float64, topK int) []SearchResult
 }
 
 // LocalStore manages the persistence and retrieval of ADR embeddings and metadata.
 type LocalStore struct {
-	ADRs      []ADR  `json:"adrs"`
-	Hash      string `json:"hash"`
-	ModelName string `json:"model_name"`
-	Dim       int    `json:"dim"`
+	ADRs        []ADR  `json:"adrs"`
+	Hash        string `json:"hash"`
+	ModelName   string `json:"model_name"`
+	Dim         int    `json:"dim"`
+	concurrency int    `json:"-"`
 }
 
 // NewLocalStore initializes a new LocalStore instance.
-func NewLocalStore() *LocalStore {
+func NewLocalStore(concurrency int) *LocalStore {
 	return &LocalStore{
-		ADRs: []ADR{},
+		ADRs:        []ADR{},
+		concurrency: concurrency,
 	}
 }
 
 // NewVectorStore creates the appropriate VectorStore based on the configuration.
 func NewVectorStore(cfg *config.Config) (VectorStore, error) {
 	if cfg.VectorStore.ConnectionString != "" {
-		return NewPgStore(cfg.VectorStore.ConnectionString, cfg.ProjectName)
+		return NewPgStore(cfg.VectorStore.ConnectionString, cfg.ProjectName, cfg.VectorStore.EmbeddingConcurrency)
 	}
-	return NewLocalStore(), nil
+	return NewLocalStore(cfg.VectorStore.EmbeddingConcurrency), nil
 }
 
 // CalculateHash generates a hash of all ADR file contents and the model name
@@ -112,56 +114,83 @@ func (s *LocalStore) Save(path string) error {
 }
 
 // BuildIndex crawls the specified directory, parses ADRs, and generates embeddings in parallel.
-func (s *LocalStore) BuildIndex(ctx context.Context, modelName string, provider llm.Provider, adrProvider Provider) error {
+// Uses Delta Indexing to skip re-computing embeddings for unchanged ADRs.
+func (s *LocalStore) BuildIndex(ctx context.Context, modelName string, dim int, provider llm.Provider, adrProvider Provider) error {
 	validADRs, err := adrProvider.GetADRs(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Found %d valid ADRs. Generating embeddings...\n", len(validADRs))
-
-	type result struct {
-		index     int
-		embedding []float32
-		err       error
-	}
-	results := make(chan result, len(validADRs))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, 5)
-
-	for i := range validADRs {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
-			emb, err := provider.CreateEmbedding(ctx, textToEmbed)
-			results <- result{index: i, embedding: emb, err: err}
-		}(i)
+	existingMap := make(map[string]ADR)
+	for _, a := range s.ADRs {
+		existingMap[a.RelPath] = a
 	}
 
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	for res := range results {
-		if res.err != nil {
-			return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
+	var adrsToEmbed []int
+	for i, valid := range validADRs {
+		existing, ok := existingMap[valid.RelPath]
+		if ok && existing.Content == valid.Content && existing.Title == valid.Title && existing.Status == valid.Status {
+			validADRs[i].Embedding = existing.Embedding
+		} else {
+			adrsToEmbed = append(adrsToEmbed, i)
 		}
-		validADRs[res.index].Embedding = res.embedding
-		fmt.Printf(".")
 	}
-	fmt.Println()
+
+	fmt.Printf("Found %d valid ADRs. Generating embeddings for %d new/modified ADRs...\n", len(validADRs), len(adrsToEmbed))
+
+	if len(adrsToEmbed) > 0 {
+		type result struct {
+			index     int
+			embedding []float32
+			err       error
+		}
+		results := make(chan result, len(adrsToEmbed))
+		var wg sync.WaitGroup
+
+		concurrency := s.concurrency
+		if concurrency <= 0 {
+			concurrency = 5
+		}
+		sem := make(chan struct{}, concurrency)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		for _, idx := range adrsToEmbed {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
+				emb, err := provider.CreateEmbedding(ctx, textToEmbed)
+				results <- result{index: i, embedding: emb, err: err}
+			}(idx)
+		}
+
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		for res := range results {
+			if res.err != nil {
+				cancel() // immediately cancel remaining API requests
+				return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
+			}
+			validADRs[res.index].Embedding = res.embedding
+			fmt.Printf(".")
+		}
+		fmt.Println()
+	}
 
 	s.ADRs = validADRs
 	s.ModelName = modelName
-	if len(validADRs) > 0 {
-		actualDim := len(validADRs[0].Embedding)
-		s.Dim = actualDim
-		fmt.Printf("Index built with %d dimensions.\n", actualDim)
+	if dim > 0 {
+		s.Dim = dim
+	} else if len(validADRs) > 0 && len(validADRs[0].Embedding) > 0 {
+		s.Dim = len(validADRs[0].Embedding)
 	}
 
 	hash, err := s.CalculateHash(validADRs, modelName)

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -18,7 +18,7 @@ func TestStore_Save_Atomic(t *testing.T) {
 		}
 	}()
 
-	store := NewLocalStore()
+	store := NewLocalStore(5)
 	store.ModelName = "mock-model"
 	store.Dim = 128
 	store.Hash = "test-hash"
@@ -46,7 +46,7 @@ func TestStore_Save_Atomic(t *testing.T) {
 		t.Fatalf("index.json.tmp was not cleaned up")
 	}
 
-	loadedStore := NewLocalStore()
+	loadedStore := NewLocalStore(5)
 	data, err := os.ReadFile(indexPath)
 	if err != nil {
 		t.Fatalf("Failed to read index.json: %v", err)


### PR DESCRIPTION
## Summary
- Migrated vector stores (PgStore and LocalStore) to use Delta Indexing, completely eliminating redundant LLM API calls for unchanged ADRs.
- Updated PgStore to perform `ON CONFLICT DO UPDATE` upserts and selectively `DELETE` removed files.
- Introduced a conditional maintenance routine for pgvector to execute `REINDEX INDEX` on heavy graph mutations.
- Updated `CompositeProvider` to fetch ADR records from diverse sources (like local and Confluence) concurrently to mask network latency.
- Hardened indexing validation guards against dimension zeroing on fresh CI runs with empty remote cache stores.

## Test Plan
- [x] Unit tests (`go test ./...`) pass, validating dimension boundary logic and early exit error handling.
- [x] Integration tests (`go test -tags=integration ./internal/index`) pass against real pgvector instances verifying the SQL index syntax.
- [ ] Perform a manual index run on an initialized repository to observe vector calculation skipping for unchanged documents.
