### PR TITLE
fix: recursive glob exclusion via doublestar

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
+	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgvector/pgvector-go/pgx v0.4.0
@@ -11,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
+	golang.org/x/net v0.57.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -70,7 +72,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"sync"
 
@@ -245,15 +244,8 @@ func (e *Engine) Run(ctx context.Context) error {
 
 func (e *Engine) shouldExclude(path string) bool {
 	for _, pattern := range e.Config.Analysis.ExcludePatterns {
-		matched, _ := filepath.Match(pattern, path)
-		if matched {
+		if matchGlob(pattern, path) {
 			return true
-		}
-		if strings.Contains(pattern, "**") {
-			prefix := strings.TrimSuffix(pattern, "**")
-			if strings.HasPrefix(path, prefix) {
-				return true
-			}
 		}
 	}
 	return false

--- a/internal/analysis/engine_internal_test.go
+++ b/internal/analysis/engine_internal_test.go
@@ -54,3 +54,28 @@ func TestFetchContext_SmartTruncation(t *testing.T) {
 		t.Errorf("Expected content to be rolled back to newline (%q), but got %q", expected, content)
 	}
 }
+
+func TestShouldExclude_RecursiveTestPattern(t *testing.T) {
+	cfg := &config.Config{
+		Analysis: config.Analysis{
+			ExcludePatterns: []string{"**/*_test.go", "vendor/**"},
+		},
+	}
+	engine := &Engine{Config: cfg}
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"foo_test.go", true},
+		{"internal/analysis/glob_test.go", true}, // regression: previously only matched exactly 2 path segments deep
+		{"internal/analysis/glob.go", false},
+		{"vendor/pkg/sub/file.go", true},
+	}
+
+	for _, c := range cases {
+		if got := engine.shouldExclude(c.path); got != c.want {
+			t.Errorf("shouldExclude(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/analysis/glob.go
+++ b/internal/analysis/glob.go
@@ -1,49 +1,13 @@
 package analysis
 
-import (
-	"path/filepath"
-	"regexp"
-	"strings"
-)
+import "github.com/bmatcuk/doublestar/v4"
 
-// matchGlob matches a file name against a glob pattern, supporting standard
-// filepath.Match patterns as well as recursive double-star (**) patterns.
+// matchGlob matches a file path against a glob pattern, supporting standard
+// single-segment wildcards as well as recursive double-star (**) patterns.
 func matchGlob(pattern, name string) bool {
-	if !strings.Contains(pattern, "**") {
-		m, _ := filepath.Match(pattern, name)
-		return m
+	matched, err := doublestar.Match(pattern, name)
+	if err != nil {
+		return false
 	}
-
-	return matchRegexGlob(pattern, name)
-}
-
-// matchRegexGlob converts a glob pattern containing double-stars into a
-// regular expression to perform recursive path matching.
-func matchRegexGlob(pattern, name string) bool {
-	var reStr strings.Builder
-	reStr.WriteString("^")
-
-	for i := 0; i < len(pattern); i++ {
-		c := pattern[i]
-		switch c {
-		case '*':
-			if i+1 < len(pattern) && pattern[i+1] == '*' {
-				reStr.WriteString(".*")
-				i++
-			} else {
-				reStr.WriteString("[^/]*")
-			}
-		case '?':
-			reStr.WriteString("[^/]")
-		case '.', '+', '(', ')', '|', '^', '$', '[', ']', '{', '}', '\\':
-			reStr.WriteString("\\")
-			reStr.WriteByte(c)
-		default:
-			reStr.WriteByte(c)
-		}
-	}
-	reStr.WriteString("$")
-
-	matched, _ := regexp.MatchString(reStr.String(), name)
 	return matched
 }

--- a/internal/analysis/glob_test.go
+++ b/internal/analysis/glob_test.go
@@ -1,0 +1,30 @@
+package analysis
+
+import "testing"
+
+func TestMatchGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"exact match", "go.sum", "go.sum", true},
+		{"exact no match", "go.sum", "go.mod", false},
+		{"single star same segment", "*.go", "main.go", true},
+		{"single star does not cross segment", "*.go", "internal/main.go", false},
+		{"double star suffix matches direct child", "vendor/**", "vendor/foo.go", true},
+		{"double star suffix matches nested", "vendor/**", "vendor/pkg/sub/foo.go", true},
+		{"double star prefix matches top-level file", "**/*_test.go", "foo_test.go", true},
+		{"double star prefix matches nested file (regression)", "**/*_test.go", "internal/analysis/glob_test.go", true},
+		{"double star prefix does not match non-test file", "**/*_test.go", "internal/analysis/glob.go", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchGlob(tt.pattern, tt.path); got != tt.want {
+				t.Errorf("matchGlob(%q, %q) = %v, want %v", tt.pattern, tt.path, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled `**` glob matcher with `github.com/bmatcuk/doublestar/v4`.
- Fixes a real bug: `**/*_test.go` (a `**` **prefix** pattern) only matched files exactly two path segments deep, because `shouldExclude` fell through to plain `filepath.Match` for prefix patterns (it only special-cased `**` as a suffix, e.g. `vendor/**`). Files like `internal/analysis/glob_test.go` (3 segments) were silently **not** excluded from architectural analysis despite the default config listing that exact pattern.
- Unifies the two previously-divergent glob implementations (`matchGlob`'s regex-based matcher and `shouldExclude`'s partial `filepath.Match`-based one) into a single call through `doublestar.Match`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New `TestMatchGlob` table test (9 cases) covering exact match, single-star same-segment, `**` suffix, `**` prefix at multiple depths
- [x] New `TestShouldExclude_RecursiveTestPattern` — regression test proving `**/*_test.go` now matches at 3+ path segments deep
- [x] `go test ./... -short` — full repo, no regressions
- [x] Independently re-verified by a review subagent (build/vet/tests re-run, regression case output inspected directly, `go.mod` dependency placement confirmed direct not indirect)

Part of a series of 8 independent library-abstraction PRs; this one only touches `internal/analysis/glob.go` and `internal/analysis/engine.go`'s `shouldExclude` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Merge note:** this PR runs `go mod tidy` against the same base commit as the other 7 PRs in this series. Most of them independently move `golang.org/x/net v0.57.0` from indirect to direct in `go.mod` — the same edit, same location. If a sibling PR merges first, this PR's `go.mod`/`go.sum` will likely show a merge conflict there. That is routine dependency-file churn, not a real blocker: resolve with GitHub's "Update branch" button (or `git fetch origin && git merge origin/main && go mod tidy && git push`).

Additionally: PR #26 (errgroup) edits the same import block in `internal/analysis/engine.go`, a few lines away (this PR removes `"path/filepath"`; #26 adds `"golang.org/x/sync/errgroup"`). Same kind of trivial conflict if #26 merges first — not a functional dependency between the two, both are independently correct.
