### PR TITLE
refactor: replace hand-rolled worker pools with errgroup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -72,7 +73,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -3,7 +3,10 @@ package analysis_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/tgenz1213/archguard/internal/analysis"
 	"github.com/tgenz1213/archguard/internal/config"
@@ -144,5 +147,58 @@ func TestCustomSystemPrompt(t *testing.T) {
 	// 6. Verify captured system prompt
 	if capturedSystemPrompt != expectedSystemPrompt {
 		t.Errorf("Expected system prompt %q, got %q", expectedSystemPrompt, capturedSystemPrompt)
+	}
+}
+
+type concurrencyTrackingProvider struct {
+	mu      sync.Mutex
+	active  int
+	maxSeen int
+	files   []string
+}
+
+func (p *concurrencyTrackingProvider) GetFiles() ([]string, error) { return p.files, nil }
+func (p *concurrencyTrackingProvider) GetContent(path string) (string, error) {
+	p.mu.Lock()
+	p.active++
+	if p.active > p.maxSeen {
+		p.maxSeen = p.active
+	}
+	p.mu.Unlock()
+
+	time.Sleep(10 * time.Millisecond)
+
+	p.mu.Lock()
+	p.active--
+	p.mu.Unlock()
+	return "package main", nil
+}
+func (p *concurrencyTrackingProvider) GetDiff(path string) (string, error) { return "", nil }
+
+func TestRun_RespectsMaxConcurrency(t *testing.T) {
+	files := make([]string, 10)
+	for i := range files {
+		files[i] = fmt.Sprintf("file%d.go", i)
+	}
+	content := &concurrencyTrackingProvider{files: files}
+
+	provider := &llm.MockProvider{}
+	store := index.NewLocalStore(5) // no ADRs -> no LLM calls, exercises the goroutine path cheaply
+
+	cfg := &config.Config{
+		Analysis: config.Analysis{MaxConcurrency: 3, ExcludePatterns: []string{}},
+	}
+
+	engine := analysis.NewEngine(cfg, store, provider, content, false, false)
+	engine.Cache = nil
+
+	if err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content.mu.Lock()
+	defer content.mu.Unlock()
+	if content.maxSeen > 3 {
+		t.Errorf("expected at most 3 concurrent GetContent calls, saw %d", content.maxSeen)
 	}
 }

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tgenz1213/archguard/internal/config"
 	"github.com/tgenz1213/archguard/internal/index"
 	"github.com/tgenz1213/archguard/internal/llm"
+	"golang.org/x/sync/errgroup"
 )
 
 // Engine coordinates the analysis of source files against ADRs using LLM providers.
@@ -78,30 +79,25 @@ func (e *Engine) Run(ctx context.Context) error {
 	var (
 		violations int
 		mu         sync.Mutex
-		wg         sync.WaitGroup
 	)
 
-	// Worker pool semaphore (concurrency limit provided by config or default 5)
 	concurrency := e.Config.Analysis.MaxConcurrency
 	if concurrency <= 0 {
 		concurrency = 5
 	}
-	sem := make(chan struct{}, concurrency)
+
+	var g errgroup.Group
+	g.SetLimit(concurrency)
 
 	for _, file := range files {
 		if e.shouldExclude(file) {
 			continue
 		}
 
-		wg.Add(1)
-		go func(file string) {
-			defer wg.Done()
-
+		file := file
+		g.Go(func() error {
 			// buffer output to ensure atomic printing per file
 			var sb strings.Builder
-
-			sem <- struct{}{}
-			defer func() { <-sem }()
 
 			if e.Debug {
 				fmt.Fprintf(&sb, "Analyzing %s...\n", file)
@@ -113,7 +109,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				mu.Lock()
 				fmt.Print(sb.String())
 				mu.Unlock()
-				return
+				return nil
 			}
 
 			if e.Debug {
@@ -125,7 +121,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				mu.Lock()
 				fmt.Print(sb.String())
 				mu.Unlock()
-				return
+				return nil
 			}
 
 			diffForEmbedding, err := e.Content.GetDiff(file)
@@ -143,7 +139,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				mu.Lock()
 				fmt.Print(sb.String())
 				mu.Unlock()
-				return
+				return nil
 			}
 
 			hits := e.Store.Search(embedding, e.Config.VectorStore.SimilarityThreshold, 3)
@@ -154,7 +150,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				mu.Lock()
 				fmt.Print(sb.String())
 				mu.Unlock()
-				return
+				return nil
 			}
 
 			localViolations := 0
@@ -230,10 +226,11 @@ func (e *Engine) Run(ctx context.Context) error {
 			fmt.Print(sb.String())
 			violations += localViolations
 			mu.Unlock()
-		}(file)
+			return nil
+		})
 	}
 
-	wg.Wait()
+	_ = g.Wait()
 
 	if violations > 0 {
 		return &DriftDetectedError{Count: violations}

--- a/internal/index/pgvector.go
+++ b/internal/index/pgvector.go
@@ -4,13 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	"sync"
-
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgvector/pgvector-go"
 	pgxvec "github.com/pgvector/pgvector-go/pgx"
 	"github.com/tgenz1213/archguard/internal/llm"
+	"golang.org/x/sync/errgroup"
 )
 
 // PgStore implements the VectorStore interface using PostgreSQL and pgvector.
@@ -130,61 +129,44 @@ func (s *PgStore) BuildIndex(ctx context.Context, modelName string, dim int, pro
 	fmt.Printf("Found %d valid ADRs. Generating embeddings for %d new/modified ADRs...\n", len(validADRs), len(adrsToEmbed))
 
 	if len(adrsToEmbed) > 0 {
-		type result struct {
-			index     int
-			embedding []float32
-			err       error
-		}
-		results := make(chan result, len(adrsToEmbed))
-		var wg sync.WaitGroup
-
 		concurrency := s.concurrency
 		if concurrency <= 0 {
 			concurrency = 5
 		}
-		sem := make(chan struct{}, concurrency)
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(concurrency)
 
 		for _, idx := range adrsToEmbed {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
+			idx := idx
+			g.Go(func() error {
+				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[idx].Title, validADRs[idx].Status, validADRs[idx].Content)
+				emb, err := provider.CreateEmbedding(gCtx, textToEmbed)
+				if err != nil {
+					return fmt.Errorf("failed to embed ADR %s: %w", validADRs[idx].RelPath, err)
+				}
+				validADRs[idx].Embedding = emb
 
-				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
-				emb, err := provider.CreateEmbedding(ctx, textToEmbed)
-				results <- result{index: i, embedding: emb, err: err}
-			}(idx)
+				vec := pgvector.NewVector(emb)
+				_, err = s.pool.Exec(gCtx, `
+					INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
+					VALUES ($1, $2, $3, $4, $5, $6)
+					ON CONFLICT (project_name, rel_path) DO UPDATE SET
+						title = EXCLUDED.title,
+						status = EXCLUDED.status,
+						content = EXCLUDED.content,
+						embedding = EXCLUDED.embedding
+				`, s.projectName, validADRs[idx].RelPath, validADRs[idx].Title, validADRs[idx].Status, validADRs[idx].Content, vec)
+				if err != nil {
+					return fmt.Errorf("failed to upsert ADR %s: %w", validADRs[idx].RelPath, err)
+				}
+				fmt.Printf(".")
+				return nil
+			})
 		}
 
-		go func() {
-			wg.Wait()
-			close(results)
-		}()
-
-		for res := range results {
-			if res.err != nil {
-				cancel() // immediately cancel remaining API requests
-				return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
-			}
-
-			vec := pgvector.NewVector(res.embedding)
-			_, err := s.pool.Exec(ctx, `
-				INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
-				VALUES ($1, $2, $3, $4, $5, $6)
-				ON CONFLICT (project_name, rel_path) DO UPDATE SET
-					title = EXCLUDED.title,
-					status = EXCLUDED.status,
-					content = EXCLUDED.content,
-					embedding = EXCLUDED.embedding
-			`, s.projectName, validADRs[res.index].RelPath, validADRs[res.index].Title, validADRs[res.index].Status, validADRs[res.index].Content, vec)
-			if err != nil {
-				return fmt.Errorf("failed to upsert ADR %s: %w", validADRs[res.index].RelPath, err)
-			}
-			fmt.Printf(".")
+		if err := g.Wait(); err != nil {
+			return err
 		}
 		fmt.Println()
 	}

--- a/internal/index/provider.go
+++ b/internal/index/provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Provider defines how ArchGuard fetches ADR documents.
@@ -29,12 +31,11 @@ func (c *CompositeProvider) GetADRs(ctx context.Context) ([]ADR, error) {
 	var allADRs []ADR
 	var errs []error
 	var mu sync.Mutex
-	var wg sync.WaitGroup
+	var g errgroup.Group
 
 	for _, p := range c.providers {
-		wg.Add(1)
-		go func(p Provider) {
-			defer wg.Done()
+		p := p
+		g.Go(func() error {
 			adrs, err := p.GetADRs(ctx)
 
 			mu.Lock()
@@ -44,12 +45,13 @@ func (c *CompositeProvider) GetADRs(ctx context.Context) ([]ADR, error) {
 				// Do not crash the entire run if one remote provider drops connection.
 				fmt.Printf("Warning: failed to fetch ADRs from a provider: %v\n", err)
 				errs = append(errs, err)
-				return
+				return nil
 			}
 			allADRs = append(allADRs, adrs...)
-		}(p)
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 
 	// If every single provider failed, then we should return an error.
 	if len(c.providers) > 0 && len(errs) == len(c.providers) {

--- a/internal/index/store.go
+++ b/internal/index/store.go
@@ -9,10 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/tgenz1213/archguard/internal/config"
 	"github.com/tgenz1213/archguard/internal/llm"
+	"golang.org/x/sync/errgroup"
 )
 
 // VectorStore defines the interface for interacting with the index storage.
@@ -139,48 +139,30 @@ func (s *LocalStore) BuildIndex(ctx context.Context, modelName string, dim int, 
 	fmt.Printf("Found %d valid ADRs. Generating embeddings for %d new/modified ADRs...\n", len(validADRs), len(adrsToEmbed))
 
 	if len(adrsToEmbed) > 0 {
-		type result struct {
-			index     int
-			embedding []float32
-			err       error
-		}
-		results := make(chan result, len(adrsToEmbed))
-		var wg sync.WaitGroup
-
 		concurrency := s.concurrency
 		if concurrency <= 0 {
 			concurrency = 5
 		}
-		sem := make(chan struct{}, concurrency)
 
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
+		g, gCtx := errgroup.WithContext(ctx)
+		g.SetLimit(concurrency)
 
 		for _, idx := range adrsToEmbed {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
-				sem <- struct{}{}
-				defer func() { <-sem }()
-
-				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[i].Title, validADRs[i].Status, validADRs[i].Content)
-				emb, err := provider.CreateEmbedding(ctx, textToEmbed)
-				results <- result{index: i, embedding: emb, err: err}
-			}(idx)
+			idx := idx
+			g.Go(func() error {
+				textToEmbed := fmt.Sprintf("Title: %s\nStatus: %s\nContent: %s", validADRs[idx].Title, validADRs[idx].Status, validADRs[idx].Content)
+				emb, err := provider.CreateEmbedding(gCtx, textToEmbed)
+				if err != nil {
+					return fmt.Errorf("failed to embed ADR %s: %w", validADRs[idx].RelPath, err)
+				}
+				validADRs[idx].Embedding = emb
+				fmt.Printf(".")
+				return nil
+			})
 		}
 
-		go func() {
-			wg.Wait()
-			close(results)
-		}()
-
-		for res := range results {
-			if res.err != nil {
-				cancel() // immediately cancel remaining API requests
-				return fmt.Errorf("failed to embed ADR %s: %w", validADRs[res.index].RelPath, res.err)
-			}
-			validADRs[res.index].Embedding = res.embedding
-			fmt.Printf(".")
+		if err := g.Wait(); err != nil {
+			return err
 		}
 		fmt.Println()
 	}

--- a/internal/index/store_test.go
+++ b/internal/index/store_test.go
@@ -1,10 +1,15 @@
 package index
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/tgenz1213/archguard/internal/llm"
 )
 
 func TestStore_Save_Atomic(t *testing.T) {
@@ -61,5 +66,63 @@ func TestStore_Save_Atomic(t *testing.T) {
 	}
 	if len(loadedStore.ADRs) != 1 {
 		t.Errorf("Expected 1 ADR, got %d", len(loadedStore.ADRs))
+	}
+}
+
+type mockADRProvider struct {
+	adrs []ADR
+	err  error
+}
+
+func (m *mockADRProvider) GetADRs(ctx context.Context) ([]ADR, error) {
+	return m.adrs, m.err
+}
+
+func TestLocalStore_BuildIndex_GeneratesEmbeddings(t *testing.T) {
+	adrs := []ADR{
+		{RelPath: "0001-a.md", Title: "A", Status: "Accepted", Content: "content a"},
+		{RelPath: "0002-b.md", Title: "B", Status: "Accepted", Content: "content b"},
+		{RelPath: "0003-c.md", Title: "C", Status: "Accepted", Content: "content c"},
+	}
+	provider := &llm.MockProvider{EmbeddingDim: 4}
+	adrProvider := &mockADRProvider{adrs: adrs}
+
+	store := NewLocalStore(2)
+	if err := store.BuildIndex(context.Background(), "mock-model", 4, provider, adrProvider); err != nil {
+		t.Fatalf("BuildIndex failed: %v", err)
+	}
+
+	if len(store.ADRs) != 3 {
+		t.Fatalf("expected 3 ADRs, got %d", len(store.ADRs))
+	}
+	for _, adr := range store.ADRs {
+		if len(adr.Embedding) != 4 {
+			t.Errorf("ADR %s: expected embedding of length 4, got %d", adr.RelPath, len(adr.Embedding))
+		}
+	}
+}
+
+func TestLocalStore_BuildIndex_ReturnsErrorOnEmbedFailure(t *testing.T) {
+	adrs := []ADR{
+		{RelPath: "0001-a.md", Title: "A", Status: "Accepted", Content: "content a"},
+		{RelPath: "0002-fails.md", Title: "B", Status: "Accepted", Content: "content b"},
+	}
+	provider := &llm.MockProvider{
+		EmbedFunc: func(ctx context.Context, text string) ([]float32, error) {
+			if strings.Contains(text, "Title: B") {
+				return nil, fmt.Errorf("simulated embedding failure")
+			}
+			return []float32{0.1, 0.2}, nil
+		},
+	}
+	adrProvider := &mockADRProvider{adrs: adrs}
+
+	store := NewLocalStore(2)
+	err := store.BuildIndex(context.Background(), "mock-model", 2, provider, adrProvider)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "0002-fails.md") {
+		t.Errorf("expected error to reference failing ADR path, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces four near-identical hand-rolled worker-pool implementations (channel semaphore + `sync.WaitGroup`, two of them with manual `context.WithCancel`-on-first-error) with `golang.org/x/sync/errgroup`, already an indirect dependency.
- `internal/analysis/engine.go` `Run` — per-file analysis fan-out, bounded by `MaxConcurrency`.
- `internal/index/store.go` `LocalStore.BuildIndex` — concurrent embedding generation.
- `internal/index/pgvector.go` `PgStore.BuildIndex` — concurrent embedding generation; **deliberately** also folds the DB upsert into the same goroutine as the embedding call (previously upserts drained sequentially off a results channel). `pgxpool.Pool` is a documented concurrency-safe connection pool, so this is safe and removes an artificial serialization point.
- `internal/index/provider.go` `CompositeProvider.GetADRs` — converted to `errgroup.Group` used purely as `WaitGroup` boilerplate reduction; deliberately does **not** use `errgroup`'s fail-fast cancellation, since the original semantics (let every provider finish, only error if *all* failed) must be preserved.

Error-wrapping message formats are unchanged (`"failed to embed ADR %s: %w"`, `"failed to upsert ADR %s: %w"`, `"all providers failed to fetch ADRs: %v"`).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] New `TestLocalStore_BuildIndex_GeneratesEmbeddings`, `TestLocalStore_BuildIndex_ReturnsErrorOnEmbedFailure` (no `BuildIndex` test existed before)
- [x] New `TestRun_RespectsMaxConcurrency` — verifies the concurrency limit is actually enforced
- [x] `go test ./... -short` — full repo, no regressions
- [x] `-race` run against `internal/index` and `internal/analysis` (via a Dockerized `golang:1.25` container, since the dev host has no cgo toolchain) — clean, no races
- [x] Real Postgres integration test (`TestPgStore_Integration`, testcontainers) run against a live pgvector container — passes, confirming the concurrent-embed-and-upsert change in `PgStore.BuildIndex` works end-to-end
- [x] Independently re-verified by a review subagent: re-ran build/vet/tests, ran its own separate `-race` pass, and directly read the `CompositeProvider.GetADRs` code to confirm it does not fail-fast (the trickiest requirement in this PR)

Part of a series of 8 independent library-abstraction PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Merge note:** this PR runs `go mod tidy` against the same base commit as the other 7 PRs in this series and moves `golang.org/x/net v0.57.0` from indirect to direct in `go.mod`, same as most siblings — expect a routine `go.mod` conflict if another PR merges first, resolved via "Update branch" or `git merge origin/main && go mod tidy`.

Additionally: PR #25 (doublestar) edits the same import block in `internal/analysis/engine.go`, a few lines away (that PR removes `"path/filepath"`; this one adds `"golang.org/x/sync/errgroup"`). Same kind of trivial conflict if #25 merges first — not a functional dependency between the two, both are independently correct.
