### PR TITLE
refactor: use cenkalti/backoff for AnalyzeDrift retry loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgvector/pgvector-go/pgx v0.4.0
@@ -23,7 +24,6 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/PuerkitoBio/goquery v1.9.2 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 /**
@@ -81,24 +83,22 @@ func GetAnalyzeDriftPrompt(adrContent, codeContext, filename string) string {
 func AnalyzeDrift(ctx context.Context, p Provider, adrContent, codeContext, filename, systemPrompt string) (*AnalysisResult, error) {
 	prompt := GetAnalyzeDriftPrompt(adrContent, codeContext, filename)
 
-	maxRetries := 3
-	backoff := 2 * time.Second
+	const maxRetries = 3
+
+	bo := backoff.NewExponentialBackOff()
+	bo.InitialInterval = 2 * time.Second
+	bo.Multiplier = 2
+	bo.RandomizationFactor = 0
+	bo.MaxElapsedTime = 0 // no overall deadline; ctx handles cancellation
+
 	var lastErr error
+	var final AnalysisResult
 
-	for i := 0; i <= maxRetries; i++ {
-		if i > 0 {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(backoff):
-				backoff *= 2
-			}
-		}
-
+	operation := func() error {
 		raw, err := p.Chat(ctx, systemPrompt, prompt)
 		if err != nil {
 			lastErr = err
-			continue
+			return err
 		}
 
 		cleaned := CleanJSON(raw)
@@ -107,13 +107,22 @@ func AnalyzeDrift(ctx context.Context, p Provider, adrContent, codeContext, file
 			// Second attempt at unmarshaling raw output
 			if err2 := json.Unmarshal([]byte(raw), &res); err2 != nil {
 				lastErr = fmt.Errorf("invalid json from provider: %w", err2)
-				continue
+				return lastErr
 			}
 		}
-		return &res, nil
+		final = res
+		return nil
 	}
 
-	return nil, fmt.Errorf("analysis failed after %d retries: %w", maxRetries, lastErr)
+	retryPolicy := backoff.WithContext(backoff.WithMaxRetries(bo, maxRetries), ctx)
+	if err := backoff.Retry(operation, retryPolicy); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("analysis failed after %d retries: %w", maxRetries, lastErr)
+	}
+
+	return &final, nil
 }
 
 func CleanJSON(input string) string {

--- a/internal/llm/llm_retry_test.go
+++ b/internal/llm/llm_retry_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -58,5 +59,21 @@ func TestAnalyzeDrift_MaxRetriesExceeded(t *testing.T) {
 
 	if attempts != 4 {
 		t.Errorf("Expected 4 attempts, got %d", attempts)
+	}
+}
+
+func TestAnalyzeDrift_ContextCancelled(t *testing.T) {
+	provider := &MockProvider{
+		ChatFunc: func(ctx context.Context, system, user string) (string, error) {
+			return "", fmt.Errorf("simulated error")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := AnalyzeDrift(ctx, provider, "adr", "code", "file.go", "system")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled fixed-3-retry, doubling-backoff loop (manual `ctx.Done()`/`time.After` select) in `internal/llm/llm.go`'s `AnalyzeDrift` with `backoff.Retry` from `github.com/cenkalti/backoff/v4`, already an indirect dependency (pulled in via testcontainers) but never used directly until now.
- Timing/attempt-count contract is preserved exactly: `InitialInterval=2s`, `Multiplier=2`, `RandomizationFactor=0` (no jitter), `WithMaxRetries(bo, 3)` → 4 total attempts (1 initial + 3 retries), matching the original byte-for-byte.
- Context cancellation still returns `ctx.Err()` unwrapped (not folded into the `"analysis failed after N retries"` message), matching the original's explicit `select` behavior.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] The two pre-existing timing-sensitive tests (`TestAnalyzeDrift_Retry`, `TestAnalyzeDrift_MaxRetriesExceeded`) pass **completely unmodified** — verified via diff that only an import and a new test function were added, nothing in their bodies changed
- [x] New `TestAnalyzeDrift_ContextCancelled` test
- [x] `go test ./internal/llm/... -v` — full package, no regressions (Gemini provider tests included)
- [x] `go test ./... -short` — full repo, no regressions
- [x] Independently re-verified by a review subagent, which traced the actual `cenkalti/backoff/v4@v4.3.0` source in the module cache to confirm the 2s/4s/8s timing math (6s and 14s durations) and the unwrapped-`ctx.Err()` cancellation path, rather than trusting the report

Part of a series of 8 independent library-abstraction PRs; only touches `internal/llm/llm.go` and `internal/llm/llm_retry_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Merge note:** this PR runs `go mod tidy` against the same base commit as the other 7 PRs in this series. Most of them independently move `golang.org/x/net v0.57.0` from indirect to direct in `go.mod` — the same edit, same location. If a sibling PR merges first, this PR's `go.mod`/`go.sum` will likely show a merge conflict there. That is routine dependency-file churn, not a real blocker: resolve with GitHub's "Update branch" button (or `git fetch origin && git merge origin/main && go mod tidy && git push`).
