### PR TITLE
refactor: use official openai-go SDK for OpenAIProvider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1
+	github.com/openai/openai-go v1.12.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgvector/pgvector-go/pgx v0.4.0
 	github.com/pkoukk/tiktoken-go v0.1.8
@@ -64,6 +65,10 @@ require (
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
+github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -140,6 +142,16 @@ github.com/testcontainers/testcontainers-go v0.43.0 h1:oEQx5MW2DGd9z3AeEQfB2lPM0
 github.com/testcontainers/testcontainers-go v0.43.0/go.mod h1:+VxkT2NQnKOZPKi6praMuMKYHYyOGXr0XSBSlSMCzFo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0 h1:ShNOFYAF4lKHvdIG258hi69bSxC88uXnxJkJvNs/IVs=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0/go.mod h1:vdq5/RqmGfWeefzyfcVI/pID1rzmc1TDvqXa15bPJks=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/internal/llm/openai.go
+++ b/internal/llm/openai.go
@@ -1,126 +1,81 @@
 package llm
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/shared"
 )
 
+const openAIBaseURL = "https://api.openai.com/v1"
+
 type OpenAIProvider struct {
-	apiKey     string
+	client     openai.Client
 	model      string
 	embedModel string
-	client     *http.Client
 }
 
+// NewOpenAIProvider constructs an OpenAIProvider that talks to the real
+// OpenAI API.
 func NewOpenAIProvider(apiKey, model, embedModel string) *OpenAIProvider {
+	return NewOpenAIProviderWithBaseURL(apiKey, model, embedModel, openAIBaseURL, &http.Client{})
+}
+
+// NewOpenAIProviderWithBaseURL constructs an OpenAIProvider pointed at a
+// custom base URL using a custom HTTP client. This exists primarily so tests
+// can inject an httptest.Server instead of hitting the real OpenAI API.
+func NewOpenAIProviderWithBaseURL(apiKey, model, embedModel, baseURL string, httpClient *http.Client) *OpenAIProvider {
+	client := openai.NewClient(
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(baseURL),
+		option.WithHTTPClient(httpClient),
+	)
 	return &OpenAIProvider{
-		apiKey:     apiKey,
+		client:     client,
 		model:      model,
 		embedModel: embedModel,
-		client:     &http.Client{},
 	}
 }
 
 func (p *OpenAIProvider) Chat(ctx context.Context, system, user string) (string, error) {
-	payload := map[string]interface{}{
-		"model": p.model,
-		"messages": []map[string]string{
-			{"role": "system", "content": system},
-			{"role": "user", "content": user},
+	resp, err := p.client.Chat.Completions.New(ctx, openai.ChatCompletionNewParams{
+		Model: p.model,
+		Messages: []openai.ChatCompletionMessageParamUnion{
+			openai.SystemMessage(system),
+			openai.UserMessage(user),
 		},
-		"response_format": map[string]string{"type": "json_object"},
-	}
-
-	var res struct {
-		Choices []struct {
-			Message struct{ Content string } `json:"message"`
-		} `json:"choices"`
-	}
-
-	err := p.post(ctx, "https://api.openai.com/v1/chat/completions", payload, &res)
+		ResponseFormat: openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONObject: &shared.ResponseFormatJSONObjectParam{},
+		},
+	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("openai chat completion failed: %w", err)
 	}
-	if len(res.Choices) == 0 {
+	if len(resp.Choices) == 0 {
 		return "", fmt.Errorf("no choices returned")
 	}
-	return res.Choices[0].Message.Content, nil
-}
-
-func (p *OpenAIProvider) post(ctx context.Context, url string, body interface{}, target interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Error closing response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("openai error: %s", resp.Status)
-	}
-
-	return json.NewDecoder(resp.Body).Decode(target)
+	return resp.Choices[0].Message.Content, nil
 }
 
 func (p *OpenAIProvider) CreateEmbedding(ctx context.Context, text string) ([]float32, error) {
-	reqBody := map[string]interface{}{
-		"input": text,
-		"model": p.embedModel,
-	}
-	jsonBody, _ := json.Marshal(reqBody)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/embeddings", bytes.NewBuffer(jsonBody))
+	resp, err := p.client.Embeddings.New(ctx, openai.EmbeddingNewParams{
+		Input: openai.EmbeddingNewParamsInputUnion{OfString: openai.String(text)},
+		Model: p.embedModel,
+	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("openai embedding request failed: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+p.apiKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Error closing response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("openai embedding api error: %s", resp.Status)
-	}
-
-	var result struct {
-		Data []struct {
-			Embedding []float32 `json:"embedding"`
-		} `json:"data"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, err
-	}
-
-	if len(result.Data) == 0 {
+	if len(resp.Data) == 0 {
 		return nil, fmt.Errorf("no embedding data returned")
 	}
 
-	return result.Data[0].Embedding, nil
+	src := resp.Data[0].Embedding
+	embedding := make([]float32, len(src))
+	for i, v := range src {
+		embedding[i] = float32(v)
+	}
+	return embedding, nil
 }

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -1,0 +1,101 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOpenAIProvider_Chat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "chat/completions") {
+			t.Errorf("expected chat/completions path, got %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-api-key" {
+			t.Errorf("expected Bearer auth header, got %q", got)
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody["model"] != "gpt-4o-mini" {
+			t.Errorf("expected model gpt-4o-mini, got %v", reqBody["model"])
+		}
+		messages, ok := reqBody["messages"].([]interface{})
+		if !ok || len(messages) != 2 {
+			t.Fatalf("expected 2 messages, got %v", reqBody["messages"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{\"violation\": false}"}}]}`))
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProviderWithBaseURL("test-api-key", "gpt-4o-mini", "text-embedding-3-small", server.URL, server.Client())
+
+	res, err := p.Chat(context.Background(), "system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+	if res != `{"violation": false}` {
+		t.Errorf("unexpected response: %q", res)
+	}
+}
+
+func TestOpenAIProvider_CreateEmbedding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "embeddings") {
+			t.Errorf("expected embeddings path, got %s", r.URL.Path)
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody["input"] != "test text" {
+			t.Errorf("expected input 'test text', got %v", reqBody["input"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"embedding":[0.1,0.2,0.3]}]}`))
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProviderWithBaseURL("test-api-key", "gpt-4o-mini", "text-embedding-3-small", server.URL, server.Client())
+
+	res, err := p.CreateEmbedding(context.Background(), "test text")
+	if err != nil {
+		t.Fatalf("CreateEmbedding failed: %v", err)
+	}
+	expected := []float32{0.1, 0.2, 0.3}
+	if len(res) != len(expected) {
+		t.Fatalf("expected length %d, got %d", len(expected), len(res))
+	}
+	for i := range res {
+		if res[i] != expected[i] {
+			t.Errorf("at index %d: expected %f, got %f", i, expected[i], res[i])
+		}
+	}
+}
+
+func TestOpenAIProvider_ChatErrorOnNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid api key"}}`))
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProviderWithBaseURL("bad-key", "gpt-4o-mini", "text-embedding-3-small", server.URL, server.Client())
+
+	_, err := p.Chat(context.Background(), "system", "user")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Migrates `internal/llm/openai.go` from hand-rolled JSON-over-HTTP (including a `post` helper that `CreateEmbedding` didn't even reuse — a third duplicate of the request-building logic) to the official `github.com/openai/openai-go` SDK.
- `NewOpenAIProvider(apiKey, model, embedModel string) *OpenAIProvider` keeps its exact production signature (`internal/cli/cli.go:113`'s call site is untouched). Added `NewOpenAIProviderWithBaseURL` as a thin wrapper for pointing the SDK client at an `httptest.Server` in tests.
- Chat uses the SDK's freeform `json_object` response-format mode (matching the original's `{"type": "json_object"}` payload — ArchGuard's JSON contract lives in prompt text, not a static schema, so `json_object` rather than `json_schema` mode is correct here).
- Embeddings: the SDK returns `[]float64`; explicitly converted to `[]float32` to match the existing `llm.Provider` interface.
- All hand-rolled HTTP/JSON plumbing (`post` helper, manual `bytes.NewBuffer`/`json.NewDecoder`) is fully removed.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] New `internal/llm/openai_test.go`: `TestOpenAIProvider_Chat`, `TestOpenAIProvider_CreateEmbedding`, `TestOpenAIProvider_ChatErrorOnNon200` — real wire-level assertions (method, path, auth header, decoded request body, round-tripped response)
- [x] `go test ./internal/llm/... -v` — full package, no regressions in Gemini/retry/CleanJSON tests
- [x] `go test ./... -short` — full repo, no regressions
- [x] Independently re-verified by a review subagent that went beyond the mock tests: read the installed SDK source directly, confirmed base-URL/path composition matches production `api.openai.com/v1` byte-for-byte, cross-checked the `[]float64`→`[]float32` conversion against the SDK's actual `Embedding` field type, marshaled the response-format struct through real SDK types to confirm wire-identical `{"type":"json_object"}` output, and exercised the real `*openai.Error` non-200 path to confirm error messages are actionable (an improvement over the original's bare status-line error)

Part of a series of 8 independent library-abstraction PRs; only touches `internal/llm/openai.go` and `internal/llm/openai_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
**Merge note:** this PR runs `go mod tidy` against the same base commit as the other 7 PRs in this series. Most of them independently move `golang.org/x/net v0.57.0` from indirect to direct in `go.mod` — the same edit, same location. If a sibling PR merges first, this PR's `go.mod`/`go.sum` will likely show a merge conflict there. That is routine dependency-file churn, not a real blocker: resolve with GitHub's "Update branch" button (or `git fetch origin && git merge origin/main && go mod tidy && git push`).
