### PR TITLE
refactor: use official ollama/ollama api client for OllamaProvider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Run Tests
         run: go test -v -race -cover ./...
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Build ArchGuard
         run: go build -v -o archguard ./cmd/archguard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First off, thank you for taking the time to contribute! ArchGuard is built on th
 
 ## Getting Started
 
-To begin contributing, you will need Go 1.25 or later and a local instance of Ollama to run the default models. Once your environment is ready, fork the repository and clone it to your local machine.
+To begin contributing, you will need Go 1.26 or later and a local instance of Ollama to run the default models. Once your environment is ready, fork the repository and clone it to your local machine.
 
 Run `go mod download` to pull the necessary dependencies, including the tokenizer and YAML parser. You can build the project locally using `go build -o archguard ./cmd/archguard`. Before submitting any changes, ensure that the binary compiles and that you have tested your logic against a local ADR directory.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Analyzing internal/db/conn.js...
 
 ### 1. Prerequisites
 
-- **Go 1.25+**: [Download Go](https://go.dev/dl/)
+- **Go 1.26+**: [Download Go](https://go.dev/dl/)
 - **Ollama**: [Download Ollama](https://ollama.com/)
 
 ### 2. Setup Models

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     
     - name: Install ArchGuard
       shell: bash

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tgenz1213/archguard
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
@@ -8,6 +8,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1
+	github.com/ollama/ollama v0.32.1
 	github.com/openai/openai-go v1.12.0
 	github.com/pgvector/pgvector-go v0.4.0
 	github.com/pgvector/pgvector-go/pgx v0.4.0
@@ -30,6 +31,8 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/PuerkitoBio/goquery v1.9.2 // indirect
 	github.com/andybalholm/cascadia v1.3.2 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
@@ -38,7 +41,7 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/dlclark/regexp2 v1.10.0 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.0 // indirect
@@ -58,6 +61,7 @@ require (
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
 	github.com/moby/moby/api v1.54.2 // indirect
@@ -80,6 +84,7 @@ require (
 	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,12 @@ github.com/PuerkitoBio/goquery v1.9.2 h1:4/wZksC3KgkQw7SQgkKotmKljk0M6V8TUvA8Wb4
 github.com/PuerkitoBio/goquery v1.9.2/go.mod h1:GHPCaP0ODyyxqcNoFGYlAprUFH81NuRPd0GX3Zu2Mvk=
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
 github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -46,8 +50,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
-github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -109,6 +113,7 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -124,6 +129,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
 github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
@@ -144,6 +151,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/ollama/ollama v0.32.1 h1:RLDnLktLMWaGGWOUV38/5cnUlcQPrlzMJ3/ihs9/pqY=
+github.com/ollama/ollama v0.32.1/go.mod h1:b1ydCt2oVg0VAg22WWDgCbwW0AyOaRKAFzlS91NI4OY=
 github.com/openai/openai-go v1.12.0 h1:NBQCnXzqOTv5wsgNC36PrFEiskGfO5wccfCWDo9S1U0=
 github.com/openai/openai-go v1.12.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -204,6 +213,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -1,11 +1,12 @@
 package llm
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"net/url"
+
+	"github.com/ollama/ollama/api"
 )
 
 type OllamaProvider struct {
@@ -13,7 +14,7 @@ type OllamaProvider struct {
 	model       string
 	embedModel  string
 	temperature float64
-	client      *http.Client
+	client      *api.Client
 }
 
 // NewOllamaProvider initializes the Ollama provider with necessary configuration.
@@ -21,12 +22,29 @@ func NewOllamaProvider(baseURL, model, embedModel string, temperature float64) *
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	}
+	return newOllamaProvider(baseURL, model, embedModel, temperature)
+}
+
+// NewOllamaProviderWithBaseURL initializes the Ollama provider pointed at the
+// given baseURL verbatim, without defaulting an empty value to localhost.
+// This exists so tests can point the provider at an httptest.Server.
+func NewOllamaProviderWithBaseURL(baseURL, model, embedModel string, temperature float64) *OllamaProvider {
+	return newOllamaProvider(baseURL, model, embedModel, temperature)
+}
+
+func newOllamaProvider(baseURL, model, embedModel string, temperature float64) *OllamaProvider {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		// Fall back to a client with no configured host; requests will fail
+		// with a descriptive error rather than panicking on a nil base URL.
+		base = &url.URL{}
+	}
 	return &OllamaProvider{
 		host:        baseURL,
 		model:       model,
 		embedModel:  embedModel,
 		temperature: temperature,
-		client:      &http.Client{},
+		client:      api.NewClient(base, http.DefaultClient),
 	}
 }
 
@@ -35,78 +53,45 @@ func NewOllamaProvider(baseURL, model, embedModel string, temperature float64) *
  */
 
 func (p *OllamaProvider) Chat(ctx context.Context, system, user string) (string, error) {
-	payload := map[string]interface{}{
-		"model":  p.model,
-		"format": "json",
-		"stream": false,
-		"options": map[string]interface{}{
+	stream := false
+	req := &api.ChatRequest{
+		Model:  p.model,
+		Stream: &stream,
+		Format: json.RawMessage(`"json"`),
+		Options: map[string]any{
 			"temperature": p.temperature,
 		},
-		"messages": []map[string]string{
-			{"role": "system", "content": system},
-			{"role": "user", "content": user},
+		Messages: []api.Message{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
 		},
 	}
 
-	var res struct {
-		Message struct {
-			Content string `json:"content"`
-		} `json:"message"`
-	}
-
-	err := p.post(ctx, p.host+"/api/chat", payload, &res)
+	var content string
+	err := p.client.Chat(ctx, req, func(res api.ChatResponse) error {
+		content = res.Message.Content
+		return nil
+	})
 	if err != nil {
 		return "", err
 	}
-	return res.Message.Content, nil
+	return content, nil
 }
 
 func (p *OllamaProvider) CreateEmbedding(ctx context.Context, text string) ([]float32, error) {
-	payload := map[string]interface{}{
-		"model":  p.embedModel,
-		"prompt": text,
+	req := &api.EmbeddingRequest{
+		Model:  p.embedModel,
+		Prompt: text,
 	}
 
-	var res struct {
-		Embedding []float32 `json:"embedding"`
-	}
-
-	err := p.post(ctx, p.host+"/api/embeddings", payload, &res)
+	res, err := p.client.Embeddings(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	return res.Embedding, nil
-}
 
-/**
- * REGION: Internal Helpers
- */
-
-func (p *OllamaProvider) post(ctx context.Context, url string, body interface{}, target interface{}) error {
-	data, err := json.Marshal(body)
-	if err != nil {
-		return err
+	embedding := make([]float32, len(res.Embedding))
+	for i, v := range res.Embedding {
+		embedding[i] = float32(v)
 	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(data))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			fmt.Printf("Error closing response body: %v\n", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("ollama api error: %s", resp.Status)
-	}
-
-	return json.NewDecoder(resp.Body).Decode(target)
+	return embedding, nil
 }

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOllamaProvider_Chat(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("expected /api/chat, got %s", r.URL.Path)
+		}
+
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody["model"] != "llama3.2" {
+			t.Errorf("expected model llama3.2, got %v", reqBody["model"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":{"role":"assistant","content":"{\"violation\": false}"},"done":true}`))
+	}))
+	defer server.Close()
+
+	p := NewOllamaProviderWithBaseURL(server.URL, "llama3.2", "nomic-embed-text", 0.0)
+
+	res, err := p.Chat(context.Background(), "system prompt", "user prompt")
+	if err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+	if res != `{"violation": false}` {
+		t.Errorf("unexpected response: %q", res)
+	}
+}
+
+func TestOllamaProvider_CreateEmbedding(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if reqBody["model"] != "nomic-embed-text" {
+			t.Errorf("expected model nomic-embed-text, got %v", reqBody["model"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"embedding":[0.1,0.2,0.3]}`))
+	}))
+	defer server.Close()
+
+	p := NewOllamaProviderWithBaseURL(server.URL, "llama3.2", "nomic-embed-text", 0.0)
+
+	res, err := p.CreateEmbedding(context.Background(), "test text")
+	if err != nil {
+		t.Fatalf("CreateEmbedding failed: %v", err)
+	}
+	expected := []float32{0.1, 0.2, 0.3}
+	if len(res) != len(expected) {
+		t.Fatalf("expected length %d, got %d", len(expected), len(res))
+	}
+	for i := range res {
+		if res[i] != expected[i] {
+			t.Errorf("at index %d: expected %f, got %f", i, expected[i], res[i])
+		}
+	}
+}
+
+func TestNewOllamaProvider_DefaultsBaseURL(t *testing.T) {
+	p := NewOllamaProvider("", "llama3.2", "nomic-embed-text", 0.0)
+	if p.host != "http://localhost:11434" {
+		t.Errorf("expected default host http://localhost:11434, got %q", p.host)
+	}
+}


### PR DESCRIPTION
## Summary
- Migrates `internal/llm/ollama.go` from hand-rolled JSON-over-HTTP to the official `github.com/ollama/ollama/api` client.
- `NewOllamaProvider(baseURL, model, embedModel string, temperature float64) *OllamaProvider` keeps its exact signature, including the empty-baseURL-defaults-to-`http://localhost:11434` behavior (`internal/cli/cli.go:115`'s call site untouched). Added `NewOllamaProviderWithBaseURL` for test injection.
- Embeddings target `/api/embeddings` via `Client.Embeddings` — the same legacy endpoint the hand-rolled code always used (confirmed against the SDK source, not the newer `/api/embed`), so no silent endpoint change.
- Hand-rolled `post` method fully removed.

**Toolchain bump (discovered mid-implementation, escalated, and explicitly decided by the repo owner):** `github.com/ollama/ollama`'s own `go.mod` requires Go 1.26 — this is true of essentially every recent release, not a version-pinning mistake. Adopting the official client therefore forces this repo's `go.mod` floor from 1.25.0 to 1.26.0. Three options were presented (bump the repo / pin an old, months-stale ollama release / abandon this one task); **bump the repo to Go 1.26** was chosen. This PR also:
- Updates all 3 `.github/workflows/ci.yml` jobs and the 1 `.github/workflows/release.yml` job from `go-version: "1.25"` to `"1.26"`.
- Updates `action.yml` (the composite GitHub Action ArchGuard ships for downstream consumers) from Go 1.25 to 1.26 — otherwise the action itself would fail to build against the bumped `go.mod`.
- Updates the Go version prerequisite text in `README.md` and `CONTRIBUTING.md` for consistency.
- Swept the whole tracked repo for other `1.25` references — nothing else needed updating (the only remaining hit is an unrelated code-analysis tool's internal metadata file, out of scope).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean (verified under a live Go 1.26.4 toolchain)
- [x] New `internal/llm/ollama_test.go`: Chat, CreateEmbedding, default-baseURL tests
- [x] `go test ./internal/llm/... -v` — full package, no regressions
- [x] `golangci-lint run --timeout=5m ./...` — whole repo, 0 issues
- [x] `go test ./... -short` — full repo, no regressions
- [x] `git diff -- .github/workflows/` reviewed to confirm the toolchain-bump commit changes only `go-version` values, nothing else
- [x] Independently re-verified by a review subagent: confirmed the call-site/signature compatibility, confirmed `/api/embeddings` against the vendored SDK source, confirmed the CI diff is minimal, and re-ran the full build/vet/test/lint suite itself rather than trusting the report

Part of a series of 8 independent library-abstraction PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Merge note:** this PR also bumps `go.mod`'s `go` directive from `1.25.0` to `1.26.0` (forced by the `ollama/ollama` dependency), plus the corresponding CI/release/action.yml/docs changes. None of the other 7 PRs in this series touch that line themselves, so this doesn't create a conflict for them — any sibling PR rebased after this one merges just picks up `1.26.0` automatically. This PR's own `go.mod` will still likely conflict with a sibling on the routine `golang.org/x/net` indirect→direct move if merged out of order — resolve via "Update branch" or `git merge origin/main && go mod tidy`.
