### PR TITLE
fix(analysis): make raw-byte truncation UTF-8 and newline safe

### DIFF
--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -130,7 +130,7 @@ func (e *Engine) Run(ctx context.Context) error {
 			}
 
 			if len(diffForEmbedding) > 6000 {
-				diffForEmbedding = diffForEmbedding[:6000]
+				diffForEmbedding = rollBackToNewline(truncateRuneSafe(diffForEmbedding, 6000))
 			}
 
 			embedding, err := e.Provider.CreateEmbedding(ctx, diffForEmbedding)
@@ -162,7 +162,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				// Check for ignore directive (optimization: only check header)
 				header := content
 				if len(header) > 2000 {
-					header = header[:2000]
+					header = truncateRuneSafe(header, 2000)
 				}
 				if strings.Contains(header, fmt.Sprintf("archguard-ignore: %s", hit.ADR.ID)) {
 					if e.Debug {
@@ -349,6 +349,21 @@ func clampRuneBoundary(s string, cut int) int {
 		cut--
 	}
 	return cut
+}
+
+// truncateRuneSafe cuts s to at most limit bytes without splitting a
+// multi-byte UTF-8 rune.
+func truncateRuneSafe(s string, limit int) string {
+	return s[:clampRuneBoundary(s, limit)]
+}
+
+// rollBackToNewline trims s back to end at its last newline character, if
+// any, so truncated content doesn't end mid-line.
+func rollBackToNewline(s string) string {
+	if lastNewline := strings.LastIndex(s, "\n"); lastNewline != -1 {
+		return s[:lastNewline+1]
+	}
+	return s
 }
 
 func (e *Engine) findLineNumber(content, quote string) int {

--- a/internal/analysis/engine_internal_test.go
+++ b/internal/analysis/engine_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/tgenz1213/archguard/internal/config"
 	"github.com/tgenz1213/archguard/internal/llm"
@@ -227,5 +228,96 @@ func TestShouldExclude_RecursiveTestPattern(t *testing.T) {
 		if got := engine.shouldExclude(c.path); got != c.want {
 			t.Errorf("shouldExclude(%q) = %v, want %v", c.path, got, c.want)
 		}
+	}
+}
+
+func TestTruncateRuneSafe(t *testing.T) {
+	cases := []struct {
+		name  string
+		s     string
+		limit int
+		want  string
+	}{
+		{"ascii under limit unchanged", "hello", 10, "hello"},
+		{"ascii exact limit unchanged", "hello", 5, "hello"},
+		{"ascii over limit cuts at byte boundary", "hello world", 5, "hello"},
+		{"2-byte rune (é) split backs up to rune start", "café", 4, "caf"},
+		{"3-byte rune (中) split backs up to rune start", "ab中cd", 4, "ab"},
+		{"4-byte rune (😀) split backs up to rune start", "hi😀jk", 4, "hi"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateRuneSafe(c.s, c.limit)
+			if got != c.want {
+				t.Errorf("truncateRuneSafe(%q, %d) = %q, want %q", c.s, c.limit, got, c.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateRuneSafe(%q, %d) = %q, not valid UTF-8", c.s, c.limit, got)
+			}
+			if len(got) > c.limit {
+				t.Errorf("truncateRuneSafe(%q, %d) = %q, exceeds limit (%d bytes)", c.s, c.limit, got, len(got))
+			}
+		})
+	}
+}
+
+func TestRollBackToNewline(t *testing.T) {
+	cases := []struct {
+		name string
+		s    string
+		want string
+	}{
+		{"no newline returns unchanged", "hello", "hello"},
+		{"trailing partial line rolled back", "line1\nline2", "line1\n"},
+		{"already ends at newline unchanged", "line1\n", "line1\n"},
+		{"multiple newlines rolls back to last", "a\nb\nc", "a\nb\n"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := rollBackToNewline(c.s); got != c.want {
+				t.Errorf("rollBackToNewline(%q) = %q, want %q", c.s, got, c.want)
+			}
+		})
+	}
+}
+
+// TestEmbeddingTruncation_MultiByteBoundary asserts the diffForEmbedding
+// truncation site (6000-byte limit) never splits a multi-byte UTF-8 rune,
+// using content engineered so a raw byte cut at 6000 would land mid-rune.
+func TestEmbeddingTruncation_MultiByteBoundary(t *testing.T) {
+	const limit = 6000
+	prefix := strings.Repeat("x", limit-2) + "\n"
+	content := prefix + "中文内容" + strings.Repeat("y", 100)
+
+	got := rollBackToNewline(truncateRuneSafe(content, limit))
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got)
+	}
+	if len(got) > limit {
+		t.Fatalf("result exceeds limit: %d bytes > %d", len(got), limit)
+	}
+	if got != prefix {
+		t.Errorf("expected rollback to prefix ending at newline (%q), got %q", prefix, got)
+	}
+}
+
+// TestIgnoreHeaderTruncation_MultiByteBoundary asserts the archguard-ignore
+// header truncation site (2000-byte limit) never splits a multi-byte UTF-8
+// rune, using content engineered so a raw byte cut at 2000 would land
+// mid-rune.
+func TestIgnoreHeaderTruncation_MultiByteBoundary(t *testing.T) {
+	const limit = 2000
+	content := strings.Repeat("x", limit-2) + "日本語" + strings.Repeat("y", 100)
+
+	got := truncateRuneSafe(content, limit)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got)
+	}
+	if len(got) > limit {
+		t.Fatalf("result exceeds limit: %d bytes > %d", len(got), limit)
 	}
 }


### PR DESCRIPTION
## Summary
- `diffForEmbedding` (6000-byte cap) and the `archguard-ignore` header check (2000-byte cap) in `internal/analysis/engine.go` sliced content by raw byte index, which could split a multi-byte UTF-8 rune.
- The embedding payload site also had no newline rollback, unlike the existing token-based truncation path, so it could cut mid-line before being sent to the provider.
- The third site named in #41 (a `maxTokens*4` byte fallback inside `fetchContext`) no longer exists — it was removed by #45's `Provider.CountTokens`-driven rewrite, which already routes all token-limit truncation through the rune-safe, newline-aware `truncateToTokenLimit`. This PR only needed to cover the two remaining raw-byte sites.
- Added `truncateRuneSafe` and `rollBackToNewline` helpers (reusing the existing `clampRuneBoundary`) and applied them at both sites.

Closes #41.

## Test plan
- [x] `go build ./...`
- [x] `go test -cover ./...` (all packages pass)
- [x] New table-driven tests (`TestTruncateRuneSafe`, `TestRollBackToNewline`) cover ASCII-unchanged behavior plus 2/3/4-byte UTF-8 rune splits (é, 中, 😀) landing exactly at a truncation boundary, asserting `utf8.ValidString`.
- [x] `TestEmbeddingTruncation_MultiByteBoundary` / `TestIgnoreHeaderTruncation_MultiByteBoundary` exercise both sites at their real 6000/2000-byte limits with multi-byte content engineered to straddle the cut.
- [ ] `golangci-lint run` — not available in this environment; CI will run it.