### PR TITLE
build(deps): group Dependabot minor/patch updates into a single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,24 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # open-pull-requests-limit stays at 5: grouping folds all routine
+    # minor/patch updates (including transitive chains like Docker/Moby/
+    # containerd via testcontainers-go, or OpenTelemetry via
+    # google.golang.org/genai) into a single PR, so 5 remains comfortable
+    # headroom even on weeks with multiple major-version bumps.
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "go"
+    groups:
+      # Batch all minor/patch updates - direct and transitive - into one
+      # PR to cut review-fatigue noise. Major versions are deliberately
+      # excluded so they keep opening as individual PRs, since they're
+      # more likely to be breaking and warrant real scrutiny.
+      go-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -20,3 +34,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      # Same rationale as the gomod group above: batch routine action
+      # version bumps, keep majors individually reviewable.
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    # Stays at 5: grouping already folds routine minor/patch updates into
-    # one PR, so this only bounds concurrent major-version bumps.
+    # Stays at 5: the grouped minor/patch PR now counts as just one slot,
+    # leaving headroom for several concurrent major-version bumps.
     open-pull-requests-limit: 5
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,20 +6,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    # open-pull-requests-limit stays at 5: grouping folds all routine
-    # minor/patch updates (including transitive chains like Docker/Moby/
-    # containerd via testcontainers-go, or OpenTelemetry via
-    # google.golang.org/genai) into a single PR, so 5 remains comfortable
-    # headroom even on weeks with multiple major-version bumps.
+    # Stays at 5: grouping already folds routine minor/patch updates into
+    # one PR, so this only bounds concurrent major-version bumps.
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "go"
     groups:
-      # Batch all minor/patch updates - direct and transitive - into one
-      # PR to cut review-fatigue noise. Major versions are deliberately
-      # excluded so they keep opening as individual PRs, since they're
-      # more likely to be breaking and warrant real scrutiny.
+      # Batches minor/patch (incl. transitive deps) into one PR; majors
+      # stay individual since they're more likely to break things.
       go-dependencies:
         update-types:
           - "minor"
@@ -35,8 +30,7 @@ updates:
       - "dependencies"
       - "github-actions"
     groups:
-      # Same rationale as the gomod group above: batch routine action
-      # version bumps, keep majors individually reviewable.
+      # Same rationale as the gomod group above.
       github-actions:
         update-types:
           - "minor"


### PR DESCRIPTION
## Summary

- Adds a `groups:` block to both the `gomod` and `github-actions` entries in `.github/dependabot.yml`, batching all `minor`/`patch` updates (via `update-types`) into one PR per ecosystem while leaving major-version bumps to keep opening individually.
- Omitting `patterns`/`dependency-type` on each group means the match is unrestricted by name or direct/indirect status, so transitive dependency chains (e.g. Docker/Moby/containerd via `testcontainers-go`, OpenTelemetry via `google.golang.org/genai`) are covered by the same grouping rule — not just direct deps.
- `open-pull-requests-limit: 5` on `gomod` is left unchanged, with a comment explaining why it's still appropriate now that routine updates consolidate into one PR.
- Existing `labels:` (`dependencies`+`go`, `dependencies`+`github-actions`) are untouched — they're set per-`updates`-entry, not per-PR-rule, so they still apply to grouped PRs automatically.

Closes #62.

## Non-goals (unchanged, per issue)

- No change to the weekly Monday schedule.
- No migration to Renovate or another tool.
- No change to how Dependabot *security*-update PRs are handled — that's a separate `applies-to: security-updates` mechanism, out of scope here.

## Deviations from plan

None of substance. One task-level review round trimmed the initial comments from 3-5 lines down to 1-2 lines to match this repo's existing terse-comment convention — see commit `a3758c3`.

## QA / testing plan

- ✅ YAML syntax validated (`python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`) — parses cleanly.
- ✅ Schema cross-checked against GitHub's dependabot.yml `groups` reference docs: `groups:` nesting, valid `update-types` values, and group-ID naming rules all confirmed correct.
- ✅ Final whole-branch review (independent, high-effort) passed "Ready to merge: Yes" with no Critical/Important code defects.
- ⚠️ **Cannot be verified from this environment — needs manual post-merge confirmation:**
  1. **Live Dependabot run.** There's no scriptable API for the "Check for updates" manual trigger (UI-only, under Insights → Dependency graph → Dependabot), and waiting for the next scheduled Monday run is outside this session. After merge, please either trigger a manual check or wait for the next Monday run, and confirm minor/patch updates actually consolidate into one grouped PR per ecosystem (including at least one indirect/transitive dependency).
  2. **Known upstream Dependabot bug to watch for:** [dependabot-core#14202](https://github.com/dependabot/dependabot-core/issues/14202) (open, filed 2026-02-17) reports that dependencies matched by a group can get marked "handled" regardless of `update-types`, which can silently suppress their major-version PRs entirely — confirmed on Maven, but rooted in shared dependabot-core matching logic, so it's a live risk here too. There's no config-level workaround that wouldn't itself violate this issue's requirement that majors stay individually reviewable. **Please also confirm, on the first live run, that a dependency with a known available major bump (e.g. check `go list -u -m all` or similar beforehand) still opens its own individual PR** — if it doesn't, that's this upstream bug, not a config defect here, and would need to be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)