### PR TITLE
docs: add PR/issue templates and standardize ticket conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Something isn't working as expected
+title: "fix: "
+labels: bug
+---
+
+## Description
+
+A clear description of the problem.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+
+- ArchGuard version/commit:
+- `llm.provider` / `vector_store.provider` (from `archguard.yaml`):
+- Go version:
+- OS:
+- Local CLI or GitHub Action:
+
+## Relevant logs / `--debug` output
+
+```
+paste here
+```
+
+## Acceptance criteria
+
+- [ ] Reproduction case above no longer errors / exits with the wrong code
+- [ ] Regression test added
+- [ ]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Propose a new capability or improvement
+title: "feat: "
+labels: enhancement
+---
+
+## Problem
+
+What's currently hard or impossible to do?
+
+## Proposed solution
+
+## Acceptance criteria
+
+Specific, testable conditions — not vague success language.
+
+- [ ]
+- [ ]
+
+## Alternatives considered
+
+## Additional context
+
+If this changes a cross-package interface or adds a new architectural constraint, note it here — it may need an ADR under `docs/arch/`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+What changed and why (1-3 sentences).
+
+## Related issue
+
+Closes #
+
+## In scope
+
+## Out of scope
+
+## Architectural notes
+
+Any new invariant, rejected alternative, or cross-cutting constraint worth recording. Link the ADR under `docs/arch/` if one was added.
+
+## Follow-ups
+
+Known gaps or deferred work, with an issue link if one exists.
+
+## Checklist
+
+- [ ] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
+- [ ] All acceptance criteria from the linked issue are met
+- [ ] `go test -race -cover ./...` passes
+- [ ] `golangci-lint run --timeout=5m` is clean
+- [ ] `CLAUDE.md` updated if this changes build/test commands, a cross-package interface, or adds a footgun
+- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision
+- [ ] Comments follow the 2-line-max, WHY-only convention

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,6 @@ Known gaps or deferred work, with an issue link if one exists.
 - [ ] All acceptance criteria from the linked issue are met
 - [ ] `go test -race -cover ./...` passes
 - [ ] `golangci-lint run --timeout=5m` is clean
-- [ ] `CLAUDE.md` updated if this changes build/test commands, a cross-package interface, or adds a footgun
+- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun
 - [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision
 - [ ] Comments follow the 2-line-max, WHY-only convention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,13 @@ Execution flow, in order: `cmd/archguard/main.go` → `internal/cli.Execute` →
 - Exit codes are meaningful and tested: `0` success, `1` general error, `2` usage, `3` config, `4` drift detected, `5` index error — preserve these in `internal/cli` if you touch command dispatch.
 - **Code comments: default to zero. When one's genuinely needed, it's 1-2 lines, never more.** Only write a comment for a non-obvious WHY (a hidden constraint, a workaround, a subtle invariant) — never to restate what the code does, narrate the task/fix that produced it, or read like a tutorial. A comment over 2 lines is bloat by default; treat that length as a hard signal to cut it down or delete it, not a reason to search for a justification. Write it plainly enough that a non-expert could follow the words even if the concept is technical. This applies everywhere, not just new code — trim a bloated comment you touch in passing. It's a deliberate rule against the tendency (especially in AI-written code) to over-explain: every extra line costs every future reader, human or AI, more than it cost to type.
 
+## Ticket & PR Conventions
+
+- Issues use the templates in `.github/ISSUE_TEMPLATE/` (bug report / feature request); PRs use `.github/PULL_REQUEST_TEMPLATE.md`.
+- Every issue needs testable **acceptance criteria** — concrete pass/fail conditions (exit codes, specific behavior, "test X added"), not a vague problem description — before work starts on it. If an issue lacks them, add them first rather than implementing against an ambiguous ask.
+- PR and commit titles follow Conventional Commits (see above). Link issues with `Closes #N`.
+- An architecturally-significant PR should add an ADR under `docs/arch/` (see "Keeping this file and the ADRs current" below) — self-apply this when opening PRs autonomously.
+
 ## Known footguns / non-obvious behavior
 
 - **`cli.Execute` rewrites `os.Args` in place before any flag parsing.** Every argument from index 2 onward that doesn't start with `-` is treated as a path and rewritten relative to the repo root, then the process `chdir`s there. This runs regardless of which subcommand is selected. If you add a subcommand with a non-path positional argument, it will still get run through `filepath.Rel` against the repo root — verify it survives that rewrite, especially in tests that invoke `Execute` from a non-root working directory.


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/` (bug report, feature request) and `.github/PULL_REQUEST_TEMPLATE.md`, and documents the resulting conventions in a new `## Ticket & PR Conventions` section in CLAUDE.md, so issues and PRs follow a consistent, testable format.

## Related issue

Closes #

## In scope

- Bug report and feature request issue templates, each with a required, testable **Acceptance Criteria** checklist.
- PR template with Summary, Related issue, In scope / Out of scope, Architectural notes, Follow-ups, and a contributor checklist (Conventional Commit title, ACs met, tests, lint, CLAUDE.md/ADR updates, comment convention).
- CLAUDE.md conventions section pointing at the templates and calling out the acceptance-criteria and ADR expectations.

## Out of scope

- No `.github/ISSUE_TEMPLATE/config.yml` (default GitHub blank-issue behavior is fine).
- No separate "ADR proposal" issue template.
- Not touching CONTRIBUTING.md's existing exit-code summary.

## Architectural notes

None — this is process/documentation only, no code or interface changes. No ADR needed.

## Follow-ups

- CONTRIBUTING.md's exit-code summary is stale relative to CLAUDE.md's (0/1/2/3/4/5) and could be reconciled in a future pass.

## Checklist

- [x] Title follows Conventional Commits
- [x] All acceptance criteria from the linked issue are met (no linked issue)
- [x] `go test -race -cover ./...` passes (no code changes)
- [x] `golangci-lint run --timeout=5m` is clean (no code changes)
- [x] `CLAUDE.md` updated
- [x] No ADR needed (not architecturally significant)
- [x] Comments follow the 2-line-max, WHY-only convention (no comments added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)