### PR TITLE
fix: report skipped-file count in --update-baseline summary

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -1,9 +1,12 @@
 package analysis_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -729,5 +732,121 @@ func TestRun_UpdateBaselineMode_CIWarnOpenDoesNotSkipFile(t *testing.T) {
 	want := baseline.Entry{ADRID: "0001", File: "service.py", QuotedCode: "import python_library"}
 	if got != want {
 		t.Errorf("expected entry %+v, got %+v", want, got)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it. Mirrors internal/index's helper of the same name.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read pipe: %v", err)
+	}
+	return buf.String()
+}
+
+// partialErrorContentProvider lets a test deterministically exercise
+// Run's per-file fail-open path via a chosen file's GetContent error.
+type partialErrorContentProvider struct {
+	files    []string
+	content  map[string]string
+	errFiles map[string]bool
+}
+
+func (p *partialErrorContentProvider) GetFiles() ([]string, error) { return p.files, nil }
+
+func (p *partialErrorContentProvider) GetContent(path string) (string, error) {
+	if p.errFiles[path] {
+		return "", fmt.Errorf("simulated read error for %s", path)
+	}
+	return p.content[path], nil
+}
+
+func (p *partialErrorContentProvider) GetDiff(path string) (string, error) {
+	return p.GetContent(path)
+}
+
+func TestRun_UpdateBaselineMode_ReportsSkippedFileCount(t *testing.T) {
+	provider := &llm.MockProvider{
+		ChatFunc: func(ctx context.Context, system, user string) (string, error) {
+			return `{
+            "violation": true,
+            "reasoning": "Python is not allowed.",
+            "quoted_code": "import python_library"
+        }`, nil
+		},
+		EmbedFunc: func(ctx context.Context, text string, task llm.EmbeddingTaskType) ([]float32, error) {
+			if strings.Contains(text, "badembed") {
+				return nil, errors.New("simulated embedding failure")
+			}
+			v := make([]float32, 1536)
+			v[0] = 1.0
+			return v, nil
+		},
+	}
+
+	store := index.NewLocalStore(5)
+	store.ADRs = []index.ADR{
+		{
+			ID:        "0001",
+			Title:     "Use Golang",
+			Status:    "Accepted",
+			Content:   "All services must be Go.",
+			Embedding: func() []float32 { v := make([]float32, 1536); v[0] = 1.0; return v }(),
+		},
+	}
+
+	cfg := &config.Config{
+		VectorStore: config.VectorStore{SimilarityThreshold: 0.0},
+		Analysis:    config.Analysis{ExcludePatterns: []string{}},
+	}
+
+	content := &partialErrorContentProvider{
+		files: []string{"good.go", "badread.go", "badembed.go"},
+		content: map[string]string{
+			"good.go":     "import python_library\n// content ignored by mock",
+			"badembed.go": "badembed marker content",
+		},
+		errFiles: map[string]bool{"badread.go": true},
+	}
+
+	engine := analysis.NewEngine(cfg, store, provider, content, false, false)
+	engine.Cache = nil
+	engine.UpdateBaseline = true
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = engine.Run(context.Background())
+	})
+	if runErr != nil {
+		t.Fatalf("expected no error in update-baseline mode, got: %v", runErr)
+	}
+
+	if engine.CollectedBaseline == nil {
+		t.Fatal("expected CollectedBaseline to be populated")
+	}
+	if len(engine.CollectedBaseline.Entries) != 1 {
+		t.Fatalf("expected exactly 1 collected entry, got %d: %+v", len(engine.CollectedBaseline.Entries), engine.CollectedBaseline.Entries)
+	}
+
+	if !strings.Contains(output, "2 file(s) skipped due to errors") {
+		t.Fatalf("expected summary to report 2 skipped files, got output: %q", output)
 	}
 }

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -101,6 +101,7 @@ func (e *Engine) Run(ctx context.Context) error {
 	var (
 		violations       int
 		baselinedCount   int
+		skippedFiles     int
 		collectedEntries []baseline.Entry
 		mu               sync.Mutex
 	)
@@ -132,6 +133,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				fmt.Fprintf(&sb, "Error reading file %s: %v\n", file, err)
 				mu.Lock()
 				fmt.Print(sb.String())
+				skippedFiles++
 				mu.Unlock()
 				return nil
 			}
@@ -170,6 +172,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				fmt.Fprintf(&sb, "Error generating embedding for %s: %v\n", file, err)
 				mu.Lock()
 				fmt.Print(sb.String())
+				skippedFiles++
 				mu.Unlock()
 				return nil
 			}
@@ -307,7 +310,7 @@ func (e *Engine) Run(ctx context.Context) error {
 			b.Add(entry.ADRID, entry.File, entry.QuotedCode)
 		}
 		e.CollectedBaseline = b
-		e.Info("Baseline scan complete: %d violation(s) recorded.", len(b.Entries))
+		e.Info("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors.", len(b.Entries), skippedFiles)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

`Engine.Run`'s two per-file fail-open error paths (a failed `fetchContext` read, a failed `CreateEmbedding` call) print a warning and skip the file with no summary-level signal in `--update-baseline` mode. This adds a `skippedFiles` counter, incremented under the existing lock alongside `violations`/`baselinedCount`, and surfaces it in the "Baseline scan complete" summary line.

## Related issue

Closes #87

## In scope

- Count files skipped due to a `fetchContext` or `CreateEmbedding` failure during `--update-baseline`.
- Report that count in the existing summary line: `Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors.`
- New test (`TestRun_UpdateBaselineMode_ReportsSkippedFileCount`) exercising both fail-open paths independently in one run.

## Out of scope

- Per-ADR LLM analysis failures (`AnalyzeDrift` errors) are not counted — issue #87 scoped this to per-*file* errors only, and that path already `continue`s past a single ADR rather than dropping the whole file.
- Surfacing the count outside `--update-baseline` (normal `check`/`check --ci` runs also skip files on these errors, but issue #87 only asked for visibility in the baseline-completeness case).

## Architectural notes

None — no new invariant or cross-cutting constraint; this only adds a counter alongside the existing `violations`/`baselinedCount` pattern in `Engine.Run`, using the same mutex.

## Follow-ups

- Folding a skipped-file count into the normal `check` summary (`%d new violation(s), %d baselined.`) as a "part two" of this visibility work.
- Counting per-ADR LLM analysis failures as a separate signal, since they're currently invisible in the same way per-file errors were before this change.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; the change only adds a counter increment inside an already-existing mutex-guarded section, so no new race surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable, no such change
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable, no architectural decision here
- [x] Comments follow the 2-line-max, WHY-only convention