### PR TITLE
fix: print baseline success message only after the file is actually saved

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -846,7 +846,10 @@ func TestRun_UpdateBaselineMode_ReportsSkippedFileCount(t *testing.T) {
 		t.Fatalf("expected exactly 1 collected entry, got %d: %+v", len(engine.CollectedBaseline.Entries), engine.CollectedBaseline.Entries)
 	}
 
-	if !strings.Contains(output, "2 file(s) skipped due to errors") {
-		t.Fatalf("expected summary to report 2 skipped files, got output: %q", output)
+	if engine.SkippedFiles != 2 {
+		t.Fatalf("expected SkippedFiles to be 2, got %d", engine.SkippedFiles)
+	}
+	if !strings.Contains(output, "Error reading file badread.go") {
+		t.Fatalf("expected per-file error to still be logged, got output: %q", output)
 	}
 }

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -38,6 +38,9 @@ type Engine struct {
 	UpdateBaseline bool
 	// CollectedBaseline is populated by Run when UpdateBaseline is true; cli.go saves it.
 	CollectedBaseline *baseline.Baseline
+	// SkippedFiles is populated by Run when UpdateBaseline is true: the count
+	// of files skipped due to per-file errors (fetchContext/CreateEmbedding failures).
+	SkippedFiles int
 }
 
 // ErrDriftDetected identifies analysis results that contain architectural violations.
@@ -310,7 +313,7 @@ func (e *Engine) Run(ctx context.Context) error {
 			b.Add(entry.ADRID, entry.File, entry.QuotedCode)
 		}
 		e.CollectedBaseline = b
-		e.Info("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors.", len(b.Entries), skippedFiles)
+		e.SkippedFiles = skippedFiles
 		return nil
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -495,6 +495,7 @@ func runCheck(cfg *config.Config, chatProvider, embedProvider llm.Provider, inde
 		if err := engine.CollectedBaseline.Save(baseline.Path); err != nil {
 			return ExitError, fmt.Errorf("failed to write baseline file %s: %v", baseline.Path, err)
 		}
+		fmt.Printf("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors.\n", len(engine.CollectedBaseline.Entries), engine.SkippedFiles)
 		fmt.Printf("Baseline written to %s (%d violation(s) recorded).\n", baseline.Path, len(engine.CollectedBaseline.Entries))
 		return ExitSuccess, nil
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -377,6 +377,65 @@ function sensitiveData() {
 	})
 }
 
+// TestE2E_BaselineMode_SaveFailureDoesNotPrintSuccess asserts the success
+// message never prints if the baseline file write itself fails.
+func TestE2E_BaselineMode_SaveFailureDoesNotPrintSuccess(t *testing.T) {
+	tempDir, binaryPath := buildE2EBinary(t)
+
+	configContent := `
+version: "1"
+llm:
+  provider: "ollama"
+vector_store:
+  provider: "ollama"
+  embedding_dim: 768
+analysis:
+  adr_path: "./docs/arch"
+  accepted_statuses: ["Accepted", "Active"]
+`
+	writeE2EConfig(t, tempDir, configContent)
+	writeNoSecretsADR(t, tempDir)
+
+	t.Log("Indexing ADRs for E2E test...")
+	runIndexCmd(t, tempDir, binaryPath, int(cli.ExitSuccess))
+
+	// Renaming onto a non-empty directory fails on both Linux and Windows,
+	// forcing Save to fail without a flaky permissions trick.
+	obstructionDir := filepath.Join(tempDir, baseline.Path)
+	if err := os.MkdirAll(obstructionDir, 0755); err != nil {
+		t.Fatalf("Failed to create obstruction directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(obstructionDir, "placeholder"), []byte("x"), 0644); err != nil {
+		t.Fatalf("Failed to create obstruction placeholder file: %v", err)
+	}
+
+	cmd := exec.Command(binaryPath, "check", "--update-baseline")
+	cmd.Dir = tempDir
+	cmd.Env = append(os.Environ(), "ARCHGUARD_API_KEY=mock_key")
+
+	out, err := cmd.CombinedOutput()
+	exitCode := 0
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		} else {
+			t.Fatalf("Binary failed to execute: %v", err)
+		}
+	}
+
+	if exitCode != int(cli.ExitError) {
+		t.Fatalf("expected exit code %d (Save failure), got %d. Output: %s", cli.ExitError, exitCode, out)
+	}
+
+	output := string(out)
+	if strings.Contains(output, "Baseline scan complete") {
+		t.Errorf("success message printed despite Save failure. Output: %s", output)
+	}
+	if !strings.Contains(output, "failed to write baseline file") {
+		t.Errorf("expected the actual Save failure to be reported. Output: %s", output)
+	}
+}
+
 // runIndexOnce executes `archguard index` once and returns its output
 // alongside the exit code actually observed.
 func runIndexOnce(t *testing.T, dir, binaryPath string) (output string, exitCode int) {


### PR DESCRIPTION
## Summary

`Engine.Run()` printed `"Baseline scan complete: ..."` directly, before returning to `cli.go`'s subsequent `engine.CollectedBaseline.Save(baseline.Path)` call. If `Save` failed, the user had already seen a success-shaped message. This moves that print into `cli.go`, after `Save` succeeds, alongside the existing `"Baseline written to ..."` line.

## Related issue

Closes #86

## In scope

- Expose the skipped-file count (added in #87) as an `Engine.SkippedFiles` field, the same pattern `CollectedBaseline` already uses, so `cli.go` can compose the full summary line itself.
- Remove the premature print from `Engine.Run`; print both summary lines in `cli.go` only after `Save` succeeds.
- New e2e test (`TestE2E_BaselineMode_SaveFailureDoesNotPrintSuccess`) that forces `Save` to fail (by pre-creating a non-empty directory at the baseline path, so the internal rename fails — verified this fails identically on both Linux and Windows) and asserts the success message never appears in the output.
- Updated `TestRun_UpdateBaselineMode_ReportsSkippedFileCount` (from #87) to assert the new `SkippedFiles` field directly, since the text it used to grep for no longer prints from `Run()`.

## Out of scope

- Consolidating the two adjacent summary lines (both currently state the violation count) into one message — noted as a "cosmetic double-summary" observation in #87's final review, but #86 only asks for correct ordering, not deduplication.
- The normal (non-`--update-baseline`) `check` summary line — untouched.

## Architectural notes

None — reuses the existing `CollectedBaseline`-field pattern for exposing `Run()` results to the caller; no new invariant or cross-cutting constraint.

## Follow-ups

None beyond what's already tracked in #104 and #105 (unrelated to this fix).

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; this change only reorders an existing print and adds a struct field, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable, no such change
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable, no architectural decision here
- [x] Comments follow the 2-line-max, WHY-only convention