### PR TITLE
docs: sync CONTRIBUTING.md exit-code summary with CLAUDE.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,5 +48,9 @@ When you are ready to submit your changes, please use **Conventional Commits** f
 When contributing to the CLI, ensure that behavioral changes respect standard exit codes:
 
 - **0**: Success (no violations found).
-- **1**: Failure (architectural violations detected or environment error).
+- **1**: General error (e.g. not run inside a git repository, baseline file I/O failure).
+- **2**: Usage error (missing/unknown command, bad flags).
+- **3**: Config error (failed to load or validate `archguard.yaml`).
+- **4**: Architectural drift detected.
+- **5**: Index error (failed to build, load, or fetch ADRs for the vector store).
 - **--ci flag**: Changes that result in truncated context should only trigger warnings in CI mode to maintain pipeline stability.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md`'s "CI and Exit Codes" section only documented `0`/`1`, while `CLAUDE.md` and `internal/cli` implement six distinct codes. This syncs the list so contributors reading only `CONTRIBUTING.md` get the accurate picture.

## Related issue

Closes #85

## In scope

- List all six exit codes (`0`-`5`) in `CONTRIBUTING.md`, matching `CLAUDE.md`'s "Conventions" section and `internal/cli`'s `ExitCode` constants.

## Out of scope

- Any code change — this is documentation-only, per the issue's own acceptance criteria.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (no code changed; ran `go build ./...` as a sanity check)
- [x] `golangci-lint run --timeout=5m` is clean (not applicable — no `.go` files changed)
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention — not applicable, no code comments touched