### PR TITLE
fix: add nil-receiver guard to Baseline.Save

### DIFF
--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -47,6 +47,10 @@ func Load(path string) (*Baseline, error) {
 }
 
 func (b *Baseline) Save(path string) error {
+	if b == nil {
+		return nil
+	}
+
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -159,6 +159,18 @@ func TestIsSuppressed_NilBaseline_ReturnsFalse(t *testing.T) {
 	}
 }
 
+func TestSave_NilBaseline_ReturnsNilError(t *testing.T) {
+	var baseline *Baseline
+	path := filepath.Join(t.TempDir(), "archguard-baseline.json")
+
+	if err := baseline.Save(path); err != nil {
+		t.Fatalf("expected nil baseline Save to return nil, got: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected no file to be written for a nil baseline, got err: %v", err)
+	}
+}
+
 func TestAdd_OverwritesExistingEntryForSameKey(t *testing.T) {
 	baseline := New()
 	baseline.Add("adr-001", "file1.go", "func main()")


### PR DESCRIPTION
## Summary

`Baseline.Add` and `Baseline.IsSuppressed` both guard against a nil receiver; `Save` didn't. Currently unreachable in production, but added for defensive consistency.

## Related issue

Closes #88

## In scope

- `Save` returns `nil` immediately on a nil receiver, consistent with `Add`'s no-op `return` and `IsSuppressed`'s `return false`.
- New test confirming both the nil return and that no file gets written as a side effect.

## Out of scope

- Any other defensive-programming pass over the codebase — scoped strictly to `Save`, per the issue.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; this is a single early-return guard, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention — no comments added, none needed