### PR TITLE
docs: sync README's documented CLI success message with actual output

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ This will automatically create the `archguard_adrs` table and safely scope all A
 
 ### Automation & Exit Codes
 
-- **Success (0)**: No architectural violations found.
+- **Success (0)**: No new architectural violations found.
 - **Violation (1)**: Architectural drift detected.
 - **Error (1)**: Configuration, environment, or indexing issues.
 


### PR DESCRIPTION
## Summary

`README.md`'s exit-code table documented the success message as "No architectural violations found." — stale since baseline mode added the "new" qualifier to the actual printed string in `internal/cli/cli.go`.

## Related issue

Closes #92

## In scope

- One-line string fix so `README.md` matches `internal/cli/cli.go:503` exactly.

## Out of scope

- Any other README accuracy pass — scoped strictly to this one string, per the issue.

## Architectural notes

None.

## Follow-ups

None in this PR — see the follow-up ticket to be opened after this merges (README's exit-code table is stale beyond just this string; only documents `0`/`1` where six codes are actually implemented, same class of issue #85 already fixed in CONTRIBUTING.md).

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (no code changed; ran `go build ./...` as a sanity check)
- [x] `golangci-lint run --timeout=5m` is clean (not applicable — no `.go` files changed)
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention — not applicable, no code comments touched