### PR TITLE
fix: gitignore the extensionless archguard build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+/archguard
 bin/
 
 # Test binaries


### PR DESCRIPTION
## Summary

`.gitignore` covered `*.exe` (Windows build output) but not the extensionless `archguard` binary that `go build -o archguard ./cmd/archguard` produces on Linux/macOS, risking an accidental commit via `git add -A`.

## Related issue

Closes #101

## In scope

- Add a root-anchored `/archguard` entry to `.gitignore`'s "Binaries" section, so only a repo-root file/dir literally named `archguard` is ignored — verified `cmd/archguard/main.go` and `archguard.yaml` are unaffected (`git check-ignore` reports no match for either), and that building the real binary now gets ignored.

## Out of scope

- Any other `.gitignore` audit — scoped strictly to this one artifact, per the issue.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (no code changed; ran full suite as a sanity check)
- [x] `golangci-lint run --timeout=5m` is clean (not applicable — no `.go` files changed)
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention — not applicable, no code comments touched