### PR TITLE
refactor: convert copy-pasted TestIsSuppressed_* tests to a table-driven test

### DIFF
--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -108,8 +108,6 @@ func TestSave_RenameFailure_CleansUpTmpFile(t *testing.T) {
 	}
 }
 
-// newBaselineWithEntry builds a *Baseline with one entry, for table rows
-// that need a pre-populated baseline.
 func newBaselineWithEntry(adrID, file, quotedCode string) *Baseline {
 	b := New()
 	b.Add(adrID, file, quotedCode)

--- a/internal/baseline/baseline_test.go
+++ b/internal/baseline/baseline_test.go
@@ -108,54 +108,87 @@ func TestSave_RenameFailure_CleansUpTmpFile(t *testing.T) {
 	}
 }
 
-func TestIsSuppressed_MatchingEntryWithQuotedCodeStillPresent_ReturnsTrue(t *testing.T) {
-	baseline := New()
-	baseline.Add("adr-001", "file1.go", "func main()")
-
-	if !baseline.IsSuppressed("adr-001", "file1.go", "package main\n\nfunc main() {\n}") {
-		t.Fatal("expected IsSuppressed to return true when quoted code is present")
-	}
+// newBaselineWithEntry builds a *Baseline with one entry, for table rows
+// that need a pre-populated baseline.
+func newBaselineWithEntry(adrID, file, quotedCode string) *Baseline {
+	b := New()
+	b.Add(adrID, file, quotedCode)
+	return b
 }
 
-func TestIsSuppressed_QuotedCodeNoLongerPresent_ReturnsFalse(t *testing.T) {
-	baseline := New()
-	baseline.Add("adr-001", "file1.go", "func main()")
-
-	if baseline.IsSuppressed("adr-001", "file1.go", "package main\n\nfunc other() {\n}") {
-		t.Fatal("expected IsSuppressed to return false when quoted code is not present")
+func TestIsSuppressed(t *testing.T) {
+	tests := []struct {
+		name           string
+		baseline       *Baseline
+		adrID          string
+		file           string
+		currentContent string
+		want           bool
+	}{
+		{
+			name:           "matching entry with quoted code still present",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", "func main()"),
+			adrID:          "adr-001",
+			file:           "file1.go",
+			currentContent: "package main\n\nfunc main() {\n}",
+			want:           true,
+		},
+		{
+			name:           "quoted code no longer present",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", "func main()"),
+			adrID:          "adr-001",
+			file:           "file1.go",
+			currentContent: "package main\n\nfunc other() {\n}",
+			want:           false,
+		},
+		{
+			name:           "empty quoted code is always suppressed",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", ""),
+			adrID:          "adr-001",
+			file:           "file1.go",
+			currentContent: "package main",
+			want:           true,
+		},
+		{
+			name:           "empty quoted code is always suppressed even with empty file content",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", ""),
+			adrID:          "adr-001",
+			file:           "file1.go",
+			currentContent: "",
+			want:           true,
+		},
+		{
+			name:           "non-matching ADR ID",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", "func main()"),
+			adrID:          "adr-002",
+			file:           "file1.go",
+			currentContent: "anything",
+			want:           false,
+		},
+		{
+			name:           "non-matching file",
+			baseline:       newBaselineWithEntry("adr-001", "file1.go", "func main()"),
+			adrID:          "adr-001",
+			file:           "file2.go",
+			currentContent: "anything",
+			want:           false,
+		},
+		{
+			name:           "nil baseline",
+			baseline:       nil,
+			adrID:          "adr-001",
+			file:           "file1.go",
+			currentContent: "anything",
+			want:           false,
+		},
 	}
-}
 
-func TestIsSuppressed_EmptyQuotedCode_AlwaysSuppressed(t *testing.T) {
-	baseline := New()
-	baseline.Add("adr-001", "file1.go", "")
-
-	if !baseline.IsSuppressed("adr-001", "file1.go", "package main") {
-		t.Fatal("expected IsSuppressed to return true for empty quoted code")
-	}
-
-	if !baseline.IsSuppressed("adr-001", "file1.go", "") {
-		t.Fatal("expected IsSuppressed to return true for empty quoted code even with empty file content")
-	}
-}
-
-func TestIsSuppressed_NoMatchingEntry_ReturnsFalse(t *testing.T) {
-	baseline := New()
-	baseline.Add("adr-001", "file1.go", "func main()")
-
-	if baseline.IsSuppressed("adr-002", "file1.go", "anything") {
-		t.Fatal("expected IsSuppressed to return false for non-matching ADR ID")
-	}
-
-	if baseline.IsSuppressed("adr-001", "file2.go", "anything") {
-		t.Fatal("expected IsSuppressed to return false for non-matching file")
-	}
-}
-
-func TestIsSuppressed_NilBaseline_ReturnsFalse(t *testing.T) {
-	var baseline *Baseline
-	if baseline.IsSuppressed("adr-001", "file1.go", "anything") {
-		t.Fatal("expected nil baseline IsSuppressed to return false")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.baseline.IsSuppressed(tt.adrID, tt.file, tt.currentContent); got != tt.want {
+				t.Errorf("IsSuppressed() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`internal/baseline/baseline_test.go` had 5 separate `TestIsSuppressed_*` functions sharing the same shape (build a baseline, call `IsSuppressed`, assert a bool) — replaced with one table-driven `TestIsSuppressed`, per CLAUDE.md's testing convention.

## Related issue

Closes #91

## In scope

- Consolidate all 5 functions into one table-driven test with 7 rows (2 of the original functions packed 2 assertions each into one body — those become 2 independently-named, independently-reportable subtest rows instead, with no case dropped or merged).
- Small `newBaselineWithEntry` helper so most rows stay one line; the nil-baseline case is just a row whose `baseline` field is the zero value `nil`.

## Out of scope

- Any other test file's copy-pasted-test cleanup — scoped strictly to `TestIsSuppressed_*`, per the issue.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met (no coverage lost — 7 rows for the 7 original assertions)
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; this is a test-only refactor, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention