### PR TITLE
refactor: extract repeated violation-formatting code from Engine.Run

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -853,3 +853,103 @@ func TestRun_UpdateBaselineMode_ReportsSkippedFileCount(t *testing.T) {
 		t.Fatalf("expected per-file error to still be logged, got output: %q", output)
 	}
 }
+
+// TestRun_ViolationOutputFormat locks in the exact printed text for each of
+// Run's three violation-handling switch arms, since no prior test did.
+func TestRun_ViolationOutputFormat(t *testing.T) {
+	provider := &llm.MockProvider{
+		ChatFunc: func(ctx context.Context, system, user string) (string, error) {
+			return `{
+            "violation": true,
+            "reasoning": "Python is not allowed.",
+            "quoted_code": "import python_library"
+        }`, nil
+		},
+	}
+	newStore := func() *index.LocalStore {
+		store := index.NewLocalStore(5)
+		store.ADRs = []index.ADR{
+			{
+				ID:        "0001",
+				Title:     "Use Golang",
+				Status:    "Accepted",
+				Content:   "All services must be Go.",
+				Embedding: func() []float32 { v := make([]float32, 1536); v[0] = 1.0; return v }(),
+			},
+		}
+		return store
+	}
+	cfg := &config.Config{
+		VectorStore: config.VectorStore{SimilarityThreshold: 0.0},
+		Analysis:    config.Analysis{ExcludePatterns: []string{}},
+	}
+	newContent := func() *MockContentProvider {
+		return &MockContentProvider{
+			Files: map[string]string{
+				"service.py": "import python_library\n// content ignored by mock",
+			},
+		}
+	}
+
+	t.Run("new violation", func(t *testing.T) {
+		engine := analysis.NewEngine(cfg, newStore(), provider, newContent(), false, false)
+		engine.Cache = nil
+
+		output := captureStdout(t, func() {
+			_ = engine.Run(context.Background())
+		})
+
+		if !strings.Contains(output, "[VIOLATION] Use Golang [Line 1]") {
+			t.Errorf("expected [VIOLATION] line, got: %q", output)
+		}
+		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
+			t.Errorf("expected Reasoning line, got: %q", output)
+		}
+		if !strings.Contains(output, "Code: import python_library") {
+			t.Errorf("expected Code line, got: %q", output)
+		}
+	})
+
+	t.Run("baselined", func(t *testing.T) {
+		b := baseline.New()
+		b.Add("0001", "service.py", "import python_library")
+
+		engine := analysis.NewEngine(cfg, newStore(), provider, newContent(), false, false)
+		engine.Cache = nil
+		engine.Baseline = b
+
+		output := captureStdout(t, func() {
+			_ = engine.Run(context.Background())
+		})
+
+		if !strings.Contains(output, "[BASELINED] Use Golang [Line 1]") {
+			t.Errorf("expected [BASELINED] line, got: %q", output)
+		}
+		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
+			t.Errorf("expected Reasoning line, got: %q", output)
+		}
+		if !strings.Contains(output, "Code: import python_library") {
+			t.Errorf("expected Code line, got: %q", output)
+		}
+	})
+
+	t.Run("update baseline", func(t *testing.T) {
+		engine := analysis.NewEngine(cfg, newStore(), provider, newContent(), false, false)
+		engine.Cache = nil
+		engine.UpdateBaseline = true
+
+		output := captureStdout(t, func() {
+			_ = engine.Run(context.Background())
+		})
+
+		if !strings.Contains(output, "[VIOLATION] Use Golang [Line 1]") {
+			t.Errorf("expected [VIOLATION] line, got: %q", output)
+		}
+		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
+			t.Errorf("expected Reasoning line, got: %q", output)
+		}
+		if !strings.Contains(output, "Code: import python_library") {
+			t.Errorf("expected Code line, got: %q", output)
+		}
+	})
+}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -895,18 +895,17 @@ func TestRun_ViolationOutputFormat(t *testing.T) {
 		engine := analysis.NewEngine(cfg, newStore(), provider, newContent(), false, false)
 		engine.Cache = nil
 
+		var runErr error
 		output := captureStdout(t, func() {
-			_ = engine.Run(context.Background())
+			runErr = engine.Run(context.Background())
 		})
 
-		if !strings.Contains(output, "[VIOLATION] Use Golang [Line 1]") {
-			t.Errorf("expected [VIOLATION] line, got: %q", output)
+		if !errors.Is(runErr, analysis.ErrDriftDetected) {
+			t.Fatalf("expected a drift-detected error, got: %v", runErr)
 		}
-		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
-			t.Errorf("expected Reasoning line, got: %q", output)
-		}
-		if !strings.Contains(output, "Code: import python_library") {
-			t.Errorf("expected Code line, got: %q", output)
+		want := "    [VIOLATION] Use Golang [Line 1]\n    Reasoning: Python is not allowed.\n    Code: import python_library\n"
+		if !strings.Contains(output, want) {
+			t.Errorf("expected exact block %q, got: %q", want, output)
 		}
 	})
 
@@ -918,18 +917,17 @@ func TestRun_ViolationOutputFormat(t *testing.T) {
 		engine.Cache = nil
 		engine.Baseline = b
 
+		var runErr error
 		output := captureStdout(t, func() {
-			_ = engine.Run(context.Background())
+			runErr = engine.Run(context.Background())
 		})
 
-		if !strings.Contains(output, "[BASELINED] Use Golang [Line 1]") {
-			t.Errorf("expected [BASELINED] line, got: %q", output)
+		if runErr != nil {
+			t.Fatalf("expected no error for a fully-baselined violation, got: %v", runErr)
 		}
-		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
-			t.Errorf("expected Reasoning line, got: %q", output)
-		}
-		if !strings.Contains(output, "Code: import python_library") {
-			t.Errorf("expected Code line, got: %q", output)
+		want := "    [BASELINED] Use Golang [Line 1]\n    Reasoning: Python is not allowed.\n    Code: import python_library\n"
+		if !strings.Contains(output, want) {
+			t.Errorf("expected exact block %q, got: %q", want, output)
 		}
 	})
 
@@ -938,18 +936,17 @@ func TestRun_ViolationOutputFormat(t *testing.T) {
 		engine.Cache = nil
 		engine.UpdateBaseline = true
 
+		var runErr error
 		output := captureStdout(t, func() {
-			_ = engine.Run(context.Background())
+			runErr = engine.Run(context.Background())
 		})
 
-		if !strings.Contains(output, "[VIOLATION] Use Golang [Line 1]") {
-			t.Errorf("expected [VIOLATION] line, got: %q", output)
+		if runErr != nil {
+			t.Fatalf("expected no error in update-baseline mode, got: %v", runErr)
 		}
-		if !strings.Contains(output, "Reasoning: Python is not allowed.") {
-			t.Errorf("expected Reasoning line, got: %q", output)
-		}
-		if !strings.Contains(output, "Code: import python_library") {
-			t.Errorf("expected Code line, got: %q", output)
+		want := "    [VIOLATION] Use Golang [Line 1]\n    Reasoning: Python is not allowed.\n    Code: import python_library\n"
+		if !strings.Contains(output, want) {
+			t.Errorf("expected exact block %q, got: %q", want, output)
 		}
 	})
 }

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -497,8 +497,6 @@ func (e *Engine) findLineNumber(content, quote string) int {
 	return len(lines)
 }
 
-// writeViolationOutput appends the shared [label]/reasoning/code lines used
-// by all three of Run's violation-handling switch arms.
 func writeViolationOutput(sb *strings.Builder, label, title string, lineNum int, reasoning, quotedCode string) {
 	fmt.Fprintf(sb, "    [%s] %s [Line %d]\n", label, title, lineNum)
 	fmt.Fprintf(sb, "    Reasoning: %s\n", reasoning)

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -259,11 +259,7 @@ func (e *Engine) Run(ctx context.Context) error {
 					lineNum := e.findLineNumber(content, res.QuotedCode)
 					switch {
 					case e.UpdateBaseline:
-						fmt.Fprintf(&sb, "    [VIOLATION] %s [Line %d]\n", hit.ADR.Title, lineNum)
-						fmt.Fprintf(&sb, "    Reasoning: %s\n", res.Reasoning)
-						if res.QuotedCode != "" {
-							fmt.Fprintf(&sb, "    Code: %s\n", res.QuotedCode)
-						}
+						writeViolationOutput(&sb, "VIOLATION", hit.ADR.Title, lineNum, res.Reasoning, res.QuotedCode)
 						// A QuotedCode that won't match the file verbatim would
 						// suppress nothing -- skip rather than write a dead entry.
 						if res.QuotedCode == "" || strings.Contains(baselineContent, res.QuotedCode) {
@@ -276,18 +272,10 @@ func (e *Engine) Run(ctx context.Context) error {
 							fmt.Fprintf(&sb, "    Warning: quoted code not found verbatim in file; skipping baseline entry\n")
 						}
 					case e.Baseline.IsSuppressed(hit.ADR.ID, file, baselineContent):
-						fmt.Fprintf(&sb, "    [BASELINED] %s [Line %d]\n", hit.ADR.Title, lineNum)
-						fmt.Fprintf(&sb, "    Reasoning: %s\n", res.Reasoning)
-						if res.QuotedCode != "" {
-							fmt.Fprintf(&sb, "    Code: %s\n", res.QuotedCode)
-						}
+						writeViolationOutput(&sb, "BASELINED", hit.ADR.Title, lineNum, res.Reasoning, res.QuotedCode)
 						localBaselined++
 					default:
-						fmt.Fprintf(&sb, "    [VIOLATION] %s [Line %d]\n", hit.ADR.Title, lineNum)
-						fmt.Fprintf(&sb, "    Reasoning: %s\n", res.Reasoning)
-						if res.QuotedCode != "" {
-							fmt.Fprintf(&sb, "    Code: %s\n", res.QuotedCode)
-						}
+						writeViolationOutput(&sb, "VIOLATION", hit.ADR.Title, lineNum, res.Reasoning, res.QuotedCode)
 						localViolations++
 					}
 				}
@@ -507,4 +495,14 @@ func (e *Engine) findLineNumber(content, quote string) int {
 
 	lines := strings.Split(content[:idx], "\n")
 	return len(lines)
+}
+
+// writeViolationOutput appends the shared [label]/reasoning/code lines used
+// by all three of Run's violation-handling switch arms.
+func writeViolationOutput(sb *strings.Builder, label, title string, lineNum int, reasoning, quotedCode string) {
+	fmt.Fprintf(sb, "    [%s] %s [Line %d]\n", label, title, lineNum)
+	fmt.Fprintf(sb, "    Reasoning: %s\n", reasoning)
+	if quotedCode != "" {
+		fmt.Fprintf(sb, "    Code: %s\n", quotedCode)
+	}
 }


### PR DESCRIPTION
## Summary

`Engine.Run`'s 3-way violation-handling switch (`UpdateBaseline`/`IsSuppressed`/`default`) repeated the same 3-line `fmt.Fprintf` block in each arm, differing only by label (`[VIOLATION]` vs `[BASELINED]`). Extracted into a shared `writeViolationOutput` helper.

## Related issue

Closes #90

## In scope

- New free function `writeViolationOutput(sb *strings.Builder, label, title string, lineNum int, reasoning, quotedCode string)`, called from all three switch arms.
- New `TestRun_ViolationOutputFormat` test — no prior test asserted on this printed text at all, so the issue's third acceptance criterion ("existing tests confirm output text is unchanged") had nothing to point at. Added a characterization test covering all three arms, verified it passes against the *pre-refactor* code first, then re-verified it passes identically after the extraction — that ordering is what actually proves the output didn't change, not just adding the test after the fact.
- Full `internal/analysis` suite re-run post-refactor confirms every existing test's printed `[VIOLATION]`/`[BASELINED]`/`Reasoning:`/`Code:` output is visibly unchanged (verified via `-v` output, not just pass/fail).

## Out of scope

- The `"Warning: quoted code not found verbatim..."` line in the `UpdateBaseline` arm — arm-specific, not repeated, stays where it is.
- Any other duplicated-code extraction in `Engine.Run` — scoped strictly to the violation-formatting block, per the issue.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met, including the previously-unmet "existing tests confirm output unchanged" (new test added, verified pre/post refactor)
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; pure refactor, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention