### PR TITLE
test: pin Execute's positional-arg path rewrite to run unconditionally

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -425,6 +425,18 @@ func TestExecute_NormalizesPositionalArgPath_EvenWhenCwdEqualsRepoRoot(t *testin
 	if err := os.Chdir(cleanRoot); err != nil {
 		t.Fatalf("failed to chdir into repo root: %v", err)
 	}
+
+	// Confirms this test actually exercises cwd == repoRoot, the same way
+	// Execute computes and compares them -- otherwise a path-canonicalization
+	// difference could silently degrade this into testing the wrong branch.
+	gotWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory after chdir: %v", err)
+	}
+	if !strings.EqualFold(filepath.Clean(gotWd), cleanRoot) {
+		t.Fatalf("precondition failed: cwd %q does not equal repoRoot %q", gotWd, cleanRoot)
+	}
+
 	// Avoids a "failed to load .env" stderr warning from godotenv.Load,
 	// unrelated to what this test is checking.
 	if err := os.WriteFile(filepath.Join(cleanRoot, ".env"), []byte(""), 0644); err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/tgenz1213/archguard/internal/analysis"
@@ -357,5 +362,84 @@ func TestNormalizePositionalArgPaths_MatchesBaselineEntryRecordedWithForwardSlas
 
 	if !b.IsSuppressed("0001", args[2], "some context\nquoted violating code\nmore context") {
 		t.Errorf("expected the normalized path %q to match a baseline entry recorded with forward slashes, but IsSuppressed returned false", args[2])
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it. Mirrors internal/analysis's helper of the same name.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("failed to read pipe: %v", err)
+	}
+	return buf.String()
+}
+
+// TestExecute_NormalizesPositionalArgPath_EvenWhenCwdEqualsRepoRoot pins
+// Execute's call site, not just the extracted function, to running unconditionally.
+func TestExecute_NormalizesPositionalArgPath_EvenWhenCwdEqualsRepoRoot(t *testing.T) {
+	origArgs := os.Args
+	origWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get original working directory: %v", err)
+	}
+	defer func() {
+		os.Args = origArgs
+		if err := os.Chdir(origWd); err != nil {
+			t.Fatalf("failed to restore working directory: %v", err)
+		}
+	}()
+
+	repoRoot := t.TempDir()
+	gitInit := exec.Command("git", "init")
+	gitInit.Dir = repoRoot
+	if out, err := gitInit.CombinedOutput(); err != nil {
+		t.Fatalf("failed to init git repo: %v\n%s", err, out)
+	}
+
+	// Resolve the same way Execute's git.GetRepoRoot() does, so cwd == repoRoot
+	// stays exact even where TMPDIR is a symlink.
+	resolvedRoot, err := exec.Command("git", "-C", repoRoot, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("failed to resolve repo root: %v", err)
+	}
+	cleanRoot := filepath.Clean(strings.TrimSpace(string(resolvedRoot)))
+
+	if err := os.Chdir(cleanRoot); err != nil {
+		t.Fatalf("failed to chdir into repo root: %v", err)
+	}
+	// Avoids a "failed to load .env" stderr warning from godotenv.Load,
+	// unrelated to what this test is checking.
+	if err := os.WriteFile(filepath.Join(cleanRoot, ".env"), []byte(""), 0644); err != nil {
+		t.Fatalf("failed to write empty .env: %v", err)
+	}
+
+	os.Args = []string{"archguard", "check", "./sub/../file.go"}
+
+	// Execute fails shortly after (no archguard.yaml here) -- irrelevant,
+	// since os.Args is already mutated by then.
+	captureStdout(t, func() {
+		_, _ = Execute(ProviderFactories{})
+	})
+
+	if os.Args[2] != "file.go" {
+		t.Errorf("expected the uncleaned positional path to be normalized to %q by Execute itself even though cwd == repoRoot, got %q", "file.go", os.Args[2])
 	}
 }


### PR DESCRIPTION
## Summary

#100's `TestNormalizePositionalArgPaths_*` tests all call the extracted `normalizePositionalArgPaths` function directly — none exercise `Execute`'s actual call site, so a regression re-wrapping that call in the old `cwd != repoRoot` guard (reintroducing #80) would pass every existing test. Added a test that calls `Execute` itself.

## Related issue

Closes #102

## In scope

- New `TestExecute_NormalizesPositionalArgPath_EvenWhenCwdEqualsRepoRoot`: bare temp git repo, chdir so `cwd == repoRoot` exactly, sets `os.Args` with an uncleaned relative path, calls `Execute(ProviderFactories{})`, and asserts `os.Args[2]` was normalized — regardless of `Execute`'s return value (it fails shortly after on missing config, which is irrelevant since normalization already ran by then).
- No `t.Parallel()` — the test mutates `os.Args` and process cwd, both process-global; saved and restored via `defer`.
- **Verified the test actually catches the regression it targets**: temporarily re-wrapped the call site in the old `if !strings.EqualFold(cwd, repoRoot)` guard, confirmed this new test fails while all existing `TestNormalizePositionalArgPaths_*` tests stay green (proving the exact coverage gap the issue describes), then reverted.
- New local `captureStdout` helper (mirrors the existing one in `internal/analysis`) to keep `Execute`'s banner print out of test output.

## Out of scope

- Any other `Execute`-level test scenario (config errors, provider errors, etc.) — scoped strictly to pinning the normalization call site, per the issue.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met, including verifying the test actually fails against the regression it targets
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; this is a test-only addition, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention