### PR TITLE
docs: document the post-upgrade re-index step for PgStore ADR ID/scope backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ archguard index
 
 This will automatically create the `archguard_adrs` table and safely scope all ADRs by your repository's Project Name, preventing conflicts across different codebases sharing the same database. ArchGuard automatically manages an HNSW vector graph on this table and uses `ON CONFLICT DO UPDATE` queries to safely maintain the database state without locking table scans.
 
+*Note:* If you're upgrading an existing PgStore install, run `archguard index` once after upgrading. A fix corrected how each ADR's ID and scope are stored in Postgres; existing rows only pick it up on their next index run, and until then `archguard-ignore` suppression, baseline scoping, and the `scope` glob filter may not work correctly for ADRs indexed before the upgrade.
+
 ---
 
 ## 📖 Usage Guide


### PR DESCRIPTION
## Summary

#93 fixed `PgStore` to persist and return each ADR's ID/scope correctly, with a lazy backfill — existing rows only sync on their next `BuildIndex` run. Nothing told existing PgStore users this action was needed. Added a note to README's pgvector section.

## Related issue

Closes #99

## In scope

- One `*Note:*`-prefixed paragraph appended to README's "Remote Vector Databases (pgvector)" section, matching the file's existing note convention (see the Delta Indexing note a few lines below), telling existing PgStore users to run `archguard index` once after upgrading and explaining what stays broken until they do (`archguard-ignore` suppression, baseline scoping, `scope` glob filtering).

## Out of scope

- Any other README accuracy pass — scoped strictly to this one note, per the issue.
- Release notes — this repo has no release-notes file to edit (GitHub Releases are auto-generated by `goreleaser` from commit messages), so README is the only available documentation surface.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (no code changed; ran `go build ./...` as a sanity check)
- [x] `golangci-lint run --timeout=5m` is clean (not applicable — no `.go` files changed)
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention — not applicable, no code comments touched