### PR TITLE
fix: count per-ADR LLM analysis failures during --update-baseline

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -950,3 +950,74 @@ func TestRun_ViolationOutputFormat(t *testing.T) {
 		}
 	})
 }
+
+// TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount asserts that a
+// per-ADR llm.AnalyzeDrift failure is counted separately from whole-file
+// skips, without blocking other ADRs' checks for the same file.
+func TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount(t *testing.T) {
+	provider := &llm.MockProvider{
+		ChatFunc: func(ctx context.Context, system, user string) (string, error) {
+			if strings.Contains(user, "BADADRMARKER") {
+				return "", errors.New("simulated LLM failure")
+			}
+			return `{
+            "violation": true,
+            "reasoning": "Python is not allowed.",
+            "quoted_code": "import python_library"
+        }`, nil
+		},
+	}
+
+	store := index.NewLocalStore(5)
+	store.ADRs = []index.ADR{
+		{
+			ID:        "0001",
+			Title:     "Use Golang",
+			Status:    "Accepted",
+			Content:   "All services must be Go.",
+			Embedding: func() []float32 { v := make([]float32, 1536); v[0] = 1.0; return v }(),
+		},
+		{
+			ID:        "0002",
+			Title:     "Bad ADR",
+			Status:    "Accepted",
+			Content:   "BADADRMARKER content.",
+			Embedding: func() []float32 { v := make([]float32, 1536); v[0] = 1.0; return v }(),
+		},
+	}
+
+	cfg := &config.Config{
+		VectorStore: config.VectorStore{SimilarityThreshold: 0.0},
+		Analysis:    config.Analysis{ExcludePatterns: []string{}},
+	}
+	content := &MockContentProvider{
+		Files: map[string]string{
+			"service.py": "import python_library\n// content ignored by mock",
+		},
+	}
+
+	engine := analysis.NewEngine(cfg, store, provider, content, false, false)
+	engine.Cache = nil
+	engine.UpdateBaseline = true
+
+	// Already-cancelled context: llm.AnalyzeDrift's real exponential-backoff
+	// retry short-circuits to zero delay once ctx is done, instead of ~14s
+	// of real sleep across 3 retries. MockProvider ignores ctx everywhere
+	// else, so this has no effect on the ADR that succeeds.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := engine.Run(ctx); err != nil {
+		t.Fatalf("expected no error in update-baseline mode, got: %v", err)
+	}
+
+	if engine.SkippedADRChecks != 1 {
+		t.Fatalf("expected SkippedADRChecks to be 1, got %d", engine.SkippedADRChecks)
+	}
+	if engine.CollectedBaseline == nil || len(engine.CollectedBaseline.Entries) != 1 {
+		t.Fatalf("expected exactly 1 collected entry from the successful ADR, got %+v", engine.CollectedBaseline)
+	}
+	if engine.CollectedBaseline.Entries[0].ADRID != "0001" {
+		t.Errorf("expected the surviving entry to be from ADR 0001, got %+v", engine.CollectedBaseline.Entries[0])
+	}
+}

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -951,9 +951,8 @@ func TestRun_ViolationOutputFormat(t *testing.T) {
 	})
 }
 
-// TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount asserts that a
-// per-ADR llm.AnalyzeDrift failure is counted separately from whole-file
-// skips, without blocking other ADRs' checks for the same file.
+// TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount asserts a failed
+// ADR check is counted without blocking other ADRs for the same file.
 func TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount(t *testing.T) {
 	provider := &llm.MockProvider{
 		ChatFunc: func(ctx context.Context, system, user string) (string, error) {

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -41,6 +41,9 @@ type Engine struct {
 	// SkippedFiles is populated by Run when UpdateBaseline is true: the count
 	// of files skipped due to per-file errors (fetchContext/CreateEmbedding failures).
 	SkippedFiles int
+	// SkippedADRChecks is populated by Run when UpdateBaseline is true: the
+	// count of per-ADR checks skipped due to llm.AnalyzeDrift failures.
+	SkippedADRChecks int
 }
 
 // ErrDriftDetected identifies analysis results that contain architectural violations.
@@ -105,6 +108,7 @@ func (e *Engine) Run(ctx context.Context) error {
 		violations       int
 		baselinedCount   int
 		skippedFiles     int
+		skippedADRChecks int
 		collectedEntries []baseline.Entry
 		mu               sync.Mutex
 	)
@@ -197,6 +201,7 @@ func (e *Engine) Run(ctx context.Context) error {
 
 			localViolations := 0
 			localBaselined := 0
+			localSkippedADRChecks := 0
 			var localBaselineEntries []baseline.Entry
 			for _, hit := range hits {
 				if hit.ADR.Scope != "" && !matchGlob(hit.ADR.Scope, file) {
@@ -246,6 +251,7 @@ func (e *Engine) Run(ctx context.Context) error {
 					res, err = llm.AnalyzeDrift(ctx, e.Provider, hit.ADR.Content, content, file, systemPrompt)
 					if err != nil {
 						fmt.Fprintf(&sb, "    Warning: LLM analysis failed: %v\n", err)
+						localSkippedADRChecks++
 						continue
 					}
 					if e.Cache != nil {
@@ -285,6 +291,7 @@ func (e *Engine) Run(ctx context.Context) error {
 			fmt.Print(sb.String())
 			violations += localViolations
 			baselinedCount += localBaselined
+			skippedADRChecks += localSkippedADRChecks
 			if e.UpdateBaseline {
 				collectedEntries = append(collectedEntries, localBaselineEntries...)
 			}
@@ -302,6 +309,7 @@ func (e *Engine) Run(ctx context.Context) error {
 		}
 		e.CollectedBaseline = b
 		e.SkippedFiles = skippedFiles
+		e.SkippedADRChecks = skippedADRChecks
 		return nil
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -495,7 +495,7 @@ func runCheck(cfg *config.Config, chatProvider, embedProvider llm.Provider, inde
 		if err := engine.CollectedBaseline.Save(baseline.Path); err != nil {
 			return ExitError, fmt.Errorf("failed to write baseline file %s: %v", baseline.Path, err)
 		}
-		fmt.Printf("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors.\n", len(engine.CollectedBaseline.Entries), engine.SkippedFiles)
+		fmt.Printf("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors, %d ADR check(s) skipped due to LLM errors.\n", len(engine.CollectedBaseline.Entries), engine.SkippedFiles, engine.SkippedADRChecks)
 		fmt.Printf("Baseline written to %s (%d violation(s) recorded).\n", baseline.Path, len(engine.CollectedBaseline.Entries))
 		return ExitSuccess, nil
 	}


### PR DESCRIPTION
## Summary

`Engine.Run`'s per-ADR loop silently `continue`s past a failed `llm.AnalyzeDrift` call with no counter or summary-level signal — flagged during #87's final review as "the largest uncounted hole" in baseline-completeness trust. Mirrors #87's `SkippedFiles` fix one level down: new `Engine.SkippedADRChecks` field, surfaced in the same `cli.go` summary line.

## Related issue

Closes #104

## In scope

- New `Engine.SkippedADRChecks int` field, incremented alongside the existing per-file counters using the same local-then-merge pattern as `SkippedFiles`.
- `cli.go`'s "Baseline scan complete" summary line extended with the new count, distinct from the whole-file-skip count.
- New regression test exercising two ADRs matching one file — one whose `AnalyzeDrift` call fails, one that succeeds — confirming the failure is counted and doesn't block the other ADR's check. Uses an already-cancelled `context.Context` to short-circuit `llm.AnalyzeDrift`'s real exponential-backoff retry (which otherwise sleeps ~14s across 3 retries on a real failure) down to zero delay; verified the test itself runs in 0.00s, confirming this actually worked rather than just passing slowly.

## Out of scope

- `llm.AnalyzeDrift`'s retry/backoff behavior — untouched, only its failure is now counted one level up.
- Surfacing this count outside `--update-baseline` — that's #105's separately-filed scope.

## Architectural notes

None — reuses the existing `SkippedFiles` field/counter pattern exactly.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; counter increments happen inside the same existing mutex-guarded merge section as `SkippedFiles`, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention