### PR TITLE
feat: surface skipped-file count outside --update-baseline

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -1021,9 +1021,8 @@ func TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount(t *testing.T) {
 	}
 }
 
-// TestRun_ReportsSkippedFileCount asserts a plain (non-update-baseline)
-// Run's summary reports files skipped due to per-file errors, reusing the
-// counter #87 introduced for --update-baseline.
+// TestRun_ReportsSkippedFileCount asserts that a non-baseline Run
+// reports files skipped due to per-file errors.
 func TestRun_ReportsSkippedFileCount(t *testing.T) {
 	provider := &llm.MockProvider{
 		ChatFunc: func(ctx context.Context, system, user string) (string, error) {

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -1020,3 +1020,57 @@ func TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount(t *testing.T) {
 		t.Errorf("expected the surviving entry to be from ADR 0001, got %+v", engine.CollectedBaseline.Entries[0])
 	}
 }
+
+// TestRun_ReportsSkippedFileCount asserts a plain (non-update-baseline)
+// Run's summary reports files skipped due to per-file errors, reusing the
+// counter #87 introduced for --update-baseline.
+func TestRun_ReportsSkippedFileCount(t *testing.T) {
+	provider := &llm.MockProvider{
+		ChatFunc: func(ctx context.Context, system, user string) (string, error) {
+			return `{
+            "violation": true,
+            "reasoning": "Python is not allowed.",
+            "quoted_code": "import python_library"
+        }`, nil
+		},
+	}
+
+	store := index.NewLocalStore(5)
+	store.ADRs = []index.ADR{
+		{
+			ID:        "0001",
+			Title:     "Use Golang",
+			Status:    "Accepted",
+			Content:   "All services must be Go.",
+			Embedding: func() []float32 { v := make([]float32, 1536); v[0] = 1.0; return v }(),
+		},
+	}
+
+	cfg := &config.Config{
+		VectorStore: config.VectorStore{SimilarityThreshold: 0.0},
+		Analysis:    config.Analysis{ExcludePatterns: []string{}},
+	}
+
+	content := &partialErrorContentProvider{
+		files: []string{"good.go", "badread.go"},
+		content: map[string]string{
+			"good.go": "import python_library\n// content ignored by mock",
+		},
+		errFiles: map[string]bool{"badread.go": true},
+	}
+
+	engine := analysis.NewEngine(cfg, store, provider, content, false, false)
+	engine.Cache = nil
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = engine.Run(context.Background())
+	})
+
+	if !errors.Is(runErr, analysis.ErrDriftDetected) {
+		t.Fatalf("expected a drift-detected error from the one real violation, got: %v", runErr)
+	}
+	if !strings.Contains(output, "1 new violation(s), 0 baselined, 1 file(s) skipped due to errors.") {
+		t.Fatalf("expected summary to report the skipped file, got output: %q", output)
+	}
+}

--- a/internal/analysis/engine.go
+++ b/internal/analysis/engine.go
@@ -313,8 +313,8 @@ func (e *Engine) Run(ctx context.Context) error {
 		return nil
 	}
 
-	if e.Baseline != nil && (violations > 0 || baselinedCount > 0) {
-		e.Info("%d new violation(s), %d baselined.", violations, baselinedCount)
+	if (e.Baseline != nil && (violations > 0 || baselinedCount > 0)) || skippedFiles > 0 {
+		e.Info("%d new violation(s), %d baselined, %d file(s) skipped due to errors.", violations, baselinedCount, skippedFiles)
 	}
 
 	if violations > 0 {


### PR DESCRIPTION
## Summary

#87 added a skipped-file count for per-file fail-open errors, surfaced only in the `--update-baseline` summary. The same errors happen identically during a normal `check`/`check --ci` run, but were never counted there. Extended the existing non-baseline summary line to include the same count.

## Related issue

Closes #105

## In scope

- `internal/analysis/engine.go`'s non-baseline summary line extended from `"%d new violation(s), %d baselined."` to `"%d new violation(s), %d baselined, %d file(s) skipped due to errors."`, reusing the `skippedFiles` counter #87 already computes.
- Print condition broadened to also fire when `skippedFiles > 0` alone (previously gated entirely behind `e.Baseline != nil && (violations > 0 || baselinedCount > 0)`), so a skip with nothing else to report doesn't go unprinted. A run with zero violations, zero baselined, and zero skips still prints nothing extra — unchanged from today.
- New regression test (`TestRun_ReportsSkippedFileCount`) covering a skipped file during a plain, non-`--update-baseline` `Run`.
- Confirmed via repo-wide grep that no existing test or caller asserts the old exact 2-clause message text, so widening the format is safe.

## Out of scope

- The `--update-baseline` summary line or its `SkippedFiles`/`SkippedADRChecks` fields — untouched.
- Counting per-ADR LLM failures in the non-baseline path — separate scope from #104.

## Architectural notes

None.

## Follow-ups

None.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -cover ./...` passes locally (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it; only a print condition/format string changed, no new concurrency surface)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention