### PR TITLE
fix: harden PgStore.BuildIndex's ADR ID/scope sync path

### DIFF
--- a/internal/index/pgvector.go
+++ b/internal/index/pgvector.go
@@ -202,7 +202,7 @@ func (s *PgStore) ensureSchema(ctx context.Context, dim int) error {
 
 	rows, err := s.pool.Query(ctx, `
 		SELECT column_name FROM information_schema.columns
-		WHERE table_name = 'archguard_adrs' AND column_name IN ('adr_id', 'scope')
+		WHERE table_name = 'archguard_adrs' AND table_schema = current_schema() AND column_name IN ('adr_id', 'scope')
 	`)
 	if err != nil {
 		return err
@@ -277,6 +277,9 @@ func (s *PgStore) BuildIndex(ctx context.Context, modelName string, dim int, pro
 			Scope:   scope,
 		}
 	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to read existing ADRs: %w", err)
+	}
 
 	var adrsToEmbed []int
 	var adrsToSync []int
@@ -339,14 +342,27 @@ func (s *PgStore) BuildIndex(ctx context.Context, modelName string, dim int, pro
 
 	if len(adrsToSync) > 0 {
 		fmt.Printf("Syncing ID/scope metadata for %d unchanged ADR(s)...\n", len(adrsToSync))
+		batch := &pgx.Batch{}
 		for _, idx := range adrsToSync {
-			_, err := s.pool.Exec(ctx, `
+			batch.Queue(`
 				UPDATE archguard_adrs SET adr_id = $1, scope = $2
 				WHERE project_name = $3 AND rel_path = $4
 			`, validADRs[idx].ID, validADRs[idx].Scope, s.projectName, validADRs[idx].RelPath)
+		}
+
+		br := s.pool.SendBatch(ctx, batch)
+		for _, idx := range adrsToSync {
+			tag, err := br.Exec()
 			if err != nil {
+				_ = br.Close()
 				return fmt.Errorf("failed to sync metadata for ADR %s: %w", validADRs[idx].RelPath, err)
 			}
+			if tag.RowsAffected() == 0 {
+				fmt.Printf("Warning: sync UPDATE for %s affected 0 rows (row may have been deleted concurrently)\n", validADRs[idx].RelPath)
+			}
+		}
+		if err := br.Close(); err != nil {
+			return fmt.Errorf("failed to close sync batch: %w", err)
 		}
 	}
 

--- a/internal/index/pgvector_integration_test.go
+++ b/internal/index/pgvector_integration_test.go
@@ -396,6 +396,51 @@ func TestPgStore_Integration_SyncsMetadataForUnchangedADR(t *testing.T) {
 	assert.Equal(t, "**/*.go", results[0].ADR.Scope, "scope should be backfilled from NULL by the sync path")
 }
 
+// TestPgStore_Integration_SyncsMetadataForScopeOnlyEdit covers the other
+// adrsToSync trigger: a scope-only edit, not a legacy NULL row.
+func TestPgStore_Integration_SyncsMetadataForScopeOnlyEdit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	connStr := setupPgContainer(t, ctx)
+
+	store, err := index.NewPgStore(connStr, "scope_only_edit_project", 5, index.HNSWOptions{})
+	require.NoError(t, err)
+	defer store.Close()
+	require.NoError(t, store.Load("", "test-model", 2, ""))
+
+	tmpDir := t.TempDir()
+	adrPath := filepath.Join(tmpDir, "0008-scope-edit.md")
+	initialContent := "---\ntitle: \"Scope Edit ADR\"\nstatus: \"Accepted\"\nscope: \"**/*.go\"\n---\nBody unchanged."
+	require.NoError(t, os.WriteFile(adrPath, []byte(initialContent), 0644))
+
+	provider := mockEmbedProvider()
+	localProvider := index.NewLocalProvider(tmpDir, []string{"Accepted"})
+
+	require.NoError(t, store.BuildIndex(ctx, "test-model", 2, provider, localProvider))
+
+	results := store.Search([]float32{0.1, 0.1}, 0.5, 5)
+	require.Len(t, results, 1)
+	assert.Equal(t, "**/*.go", results[0].ADR.Scope, "initial index should embed the original scope")
+
+	// Same title/status/body -- only the scope: frontmatter value changes.
+	editedContent := "---\ntitle: \"Scope Edit ADR\"\nstatus: \"Accepted\"\nscope: \"**/*.ts\"\n---\nBody unchanged."
+	require.NoError(t, os.WriteFile(adrPath, []byte(editedContent), 0644))
+
+	output := captureStdout(t, func() {
+		err = store.BuildIndex(ctx, "test-model", 2, provider, localProvider)
+	})
+	require.NoError(t, err)
+	assert.Contains(t, output, "Generating embeddings for 0 new/modified ADRs", "content/title/status are unchanged, so this must NOT re-embed")
+	assert.Contains(t, output, "Syncing ID/scope metadata for 1 unchanged ADR", "the scope-only change must route through the sync path")
+
+	results = store.Search([]float32{0.1, 0.1}, 0.5, 5)
+	require.Len(t, results, 1)
+	assert.Equal(t, "**/*.ts", results[0].ADR.Scope, "sync path must pick up the new scope value")
+}
+
 // TestPgStore_Integration_BuildIndexMigratesLegacyTableWithoutLoad reproduces
 // cli.runIndex's call pattern (BuildIndex with no preceding Load) against a
 // table created with the pre-migration schema, to prove BuildIndex can bring


### PR DESCRIPTION
## Summary

Five issues, all split out from #93, all touching the same small region of `PgStore.ensureSchema`/`BuildIndex`. Bundled into one PR since #94 and #95 touch the exact same lines.

## Related issues

Closes #94, Closes #95, Closes #96, Closes #97, Closes #98

## In scope

- **#97**: `ensureSchema`'s `information_schema.columns` check now scopes to `table_schema = current_schema()`, so it can't under/over-detect columns when `archguard_adrs` exists in more than one schema on the search path.
- **#96**: `BuildIndex`'s `existingMap` read loop now checks `rows.Err()` after iterating, so a mid-stream query error (connection drop, etc.) fails loudly instead of silently treating every unread row as absent.
- **#95 + #94**: the sync-path `UPDATE`s are now batched into one round trip via `pgx.Batch`/`SendBatch` instead of N sequential `Exec` calls, and each result's `RowsAffected()` is checked — a zero-row update (e.g. the row was deleted by a concurrent `BuildIndex`) now logs a warning instead of silently no-opping. Implemented together since batching requires reading results back, which is exactly where the affected-rows check belongs.
- **#98**: new integration test (`TestPgStore_Integration_SyncsMetadataForScopeOnlyEdit`) covering the other `adrsToSync` trigger — a scope-only frontmatter edit — alongside the existing legacy-NULL-row test.

All four integration tests in the file (existing + new) verified passing against a real Postgres container (Docker, testcontainers-go) locally, not just built.

## Out of scope

- Any other `PgStore` correctness pass beyond these five specific issues.
- The embed path's own `INSERT ... ON CONFLICT DO UPDATE` — untouched, already atomic, not part of any of these five issues.

## Architectural notes

None — these are hardening fixes to an existing sync path, not new invariants.

## Follow-ups

A `/code-review` pass on this diff surfaced one adjacent, pre-existing issue not covered by any of #94-#98: `existingMap`'s read loop silently `continue`s past a `rows.Scan` error (as opposed to the `rows.Err()` iteration-level error this PR now checks), which could cause an unrelated row to be wrongly treated as new/modified and needlessly re-embedded with no visible cause. Filing a follow-up issue for it rather than expanding this PR's scope.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from all five linked issues are met
- [x] `go test -cover ./...` passes locally, including the full non-`-short` integration suite against a real Postgres container (`-race` requires cgo, unavailable in this dev environment — CI's race job covers it)
- [x] `golangci-lint run --timeout=5m` is clean
- [ ] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun — not applicable, no interface/package change
- [ ] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision — not applicable
- [x] Comments follow the 2-line-max, WHY-only convention