### PR TITLE
docs: document all six exit codes in README's Automation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,12 @@ This will automatically create the `archguard_adrs` table and safely scope all A
 
 ### Automation & Exit Codes
 
-- **Success (0)**: No new architectural violations found.
-- **Violation (1)**: Architectural drift detected.
-- **Error (1)**: Configuration, environment, or indexing issues.
+- **0**: Success (no new violations found; baselined violations still exit 0).
+- **1**: General error (e.g. not run inside a git repository, baseline file I/O failure).
+- **2**: Usage error (missing/unknown command, bad flags).
+- **3**: Config error (failed to load or validate `archguard.yaml`).
+- **4**: Architectural drift detected.
+- **5**: Index error (failed to build, load, or fetch ADRs for the vector store).
 
 ### Suppression
 


### PR DESCRIPTION
## Summary

README's "Automation & Exit Codes" section only documented codes 0/1 and mislabeled drift detection as exit code 1 (it's actually 4); this brings it in line with `internal/cli`'s actual `ExitCode` constants, mirroring the table CONTRIBUTING.md already has after #85.

## Related issue

Closes #110

## In scope

- README.md's "Automation & Exit Codes" section: all six exit codes (0-5) with accurate descriptions

## Out of scope

- Any behavioral/code change (docs-only per the issue's acceptance criteria)

## Architectural notes

None — documentation-only change, no new invariant or cross-cutting constraint.

## Follow-ups

None identified.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -race -cover ./...` passes
- [x] `golangci-lint run --timeout=5m` is clean
- [x] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun (N/A — docs-only)
- [x] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision (N/A)
- [x] Comments follow the 2-line-max, WHY-only convention (N/A — no code comments touched)