### PR TITLE
test: add fast unit coverage for the composed --update-baseline summary text

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -495,13 +495,23 @@ func runCheck(cfg *config.Config, chatProvider, embedProvider llm.Provider, inde
 		if err := engine.CollectedBaseline.Save(baseline.Path); err != nil {
 			return ExitError, fmt.Errorf("failed to write baseline file %s: %v", baseline.Path, err)
 		}
-		fmt.Printf("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors, %d ADR check(s) skipped due to LLM errors.\n", len(engine.CollectedBaseline.Entries), engine.SkippedFiles, engine.SkippedADRChecks)
-		fmt.Printf("Baseline written to %s (%d violation(s) recorded).\n", baseline.Path, len(engine.CollectedBaseline.Entries))
+		fmt.Println(formatBaselineScanSummary(len(engine.CollectedBaseline.Entries), engine.SkippedFiles, engine.SkippedADRChecks))
+		fmt.Println(formatBaselineWrittenSummary(baseline.Path, len(engine.CollectedBaseline.Entries)))
 		return ExitSuccess, nil
 	}
 
 	fmt.Println("No new architectural violations found.")
 	return ExitSuccess, nil
+}
+
+// formatBaselineScanSummary is its own function so runCheck's exact summary
+// wording is unit-testable without the engine/LLM pipeline that feeds it.
+func formatBaselineScanSummary(violations, skippedFiles, skippedADRChecks int) string {
+	return fmt.Sprintf("Baseline scan complete: %d violation(s) recorded, %d file(s) skipped due to errors, %d ADR check(s) skipped due to LLM errors.", violations, skippedFiles, skippedADRChecks)
+}
+
+func formatBaselineWrittenSummary(path string, violations int) string {
+	return fmt.Sprintf("Baseline written to %s (%d violation(s) recorded).", path, violations)
 }
 
 // resolveContentProvider picks the ContentProvider for a check run.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -455,3 +455,40 @@ func TestExecute_NormalizesPositionalArgPath_EvenWhenCwdEqualsRepoRoot(t *testin
 		t.Errorf("expected the uncleaned positional path to be normalized to %q by Execute itself even though cwd == repoRoot, got %q", "file.go", os.Args[2])
 	}
 }
+
+func TestFormatBaselineScanSummary(t *testing.T) {
+	tests := []struct {
+		name                                       string
+		violations, skippedFiles, skippedADRChecks int
+		want                                       string
+	}{
+		{
+			name: "all zero", violations: 0, skippedFiles: 0, skippedADRChecks: 0,
+			want: "Baseline scan complete: 0 violation(s) recorded, 0 file(s) skipped due to errors, 0 ADR check(s) skipped due to LLM errors.",
+		},
+		{
+			name: "nonzero ADR checks skipped", violations: 1, skippedFiles: 0, skippedADRChecks: 1,
+			want: "Baseline scan complete: 1 violation(s) recorded, 0 file(s) skipped due to errors, 1 ADR check(s) skipped due to LLM errors.",
+		},
+		{
+			name: "all nonzero, distinct values", violations: 3, skippedFiles: 2, skippedADRChecks: 5,
+			want: "Baseline scan complete: 3 violation(s) recorded, 2 file(s) skipped due to errors, 5 ADR check(s) skipped due to LLM errors.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBaselineScanSummary(tt.violations, tt.skippedFiles, tt.skippedADRChecks)
+			if got != tt.want {
+				t.Errorf("formatBaselineScanSummary(%d, %d, %d) = %q, want %q", tt.violations, tt.skippedFiles, tt.skippedADRChecks, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatBaselineWrittenSummary(t *testing.T) {
+	got := formatBaselineWrittenSummary("archguard-baseline.json", 3)
+	want := "Baseline written to archguard-baseline.json (3 violation(s) recorded)."
+	if got != want {
+		t.Errorf("formatBaselineWrittenSummary(...) = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit coverage for the exact composed "Baseline scan complete: ..." and "Baseline written to ..." strings by extracting them into two small, pure functions (`formatBaselineScanSummary`, `formatBaselineWrittenSummary`) and testing those directly with table-driven cases.

## Related issue

Closes #121

## In scope

- `internal/cli/cli.go`: extract the two `--update-baseline` summary `Printf` calls into named functions (output is byte-identical; pure refactor)
- `internal/cli/cli_test.go`: `TestFormatBaselineScanSummary` (table-driven: zero counts, nonzero ADR-check-skip count, all-distinct-nonzero counts) and `TestFormatBaselineWrittenSummary`

## Out of scope

- Any behavioral change to the printed output itself

## Architectural notes

None — no new invariant; the extraction is a pure refactor with identical output, verified by keeping the exact same format strings.

## Follow-ups

None open. Note on process: this PR went through two design iterations before landing here, both driven by code review.

**First iteration** (original commit) called `runCheck` directly through a full temp-git-repo + mocked-provider integration setup, per the issue's suggested cli_test.go-level approach. Review of that version surfaced:
1. It paid `llm.AnalyzeDrift`'s real ~14s exponential backoff on every test run, since `runCheck` hardcodes `context.Background()` with no injection point.
2. It substantially duplicated a scenario already covered instantly (0.00s) by `internal/analysis/analysis_test.go`'s `TestRun_UpdateBaselineMode_ReportsSkippedADRCheckCount` — the *only* genuinely new value was pinning the CLI's exact composed string, which didn't require re-exercising the whole engine/backoff pipeline.
3. Several comments exceeded CLAUDE.md's 2-line cap.
4. The second summary line (`"Baseline written to ..."`) was never asserted.

**Second iteration** (current) replaces that integration test with the extraction described above, which resolves all four points at once: 0.00s instead of ~14s, no duplicated coverage, no oversized comments, and both summary lines now covered directly.

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -race -cover ./...` passes
- [x] `golangci-lint run --timeout=5m` is clean
- [x] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun (N/A)
- [x] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision (N/A)
- [x] Comments follow the 2-line-max, WHY-only convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)