### PR TITLE
fix: give BuildIndex's existing-ADR scan failure a specific, actionable error

### DIFF
--- a/internal/index/pgvector.go
+++ b/internal/index/pgvector.go
@@ -267,7 +267,7 @@ func (s *PgStore) BuildIndex(ctx context.Context, modelName string, dim int, pro
 	for rows.Next() {
 		var relPath, title, status, content, adrID, scope string
 		if err := rows.Scan(&relPath, &title, &status, &content, &adrID, &scope); err != nil {
-			continue
+			return fmt.Errorf("failed to scan existing ADR row: %w", err)
 		}
 		existingMap[relPath] = ADR{
 			ID:      adrID,

--- a/internal/index/pgvector_integration_test.go
+++ b/internal/index/pgvector_integration_test.go
@@ -496,6 +496,44 @@ func TestPgStore_Integration_BuildIndexMigratesLegacyTableWithoutLoad(t *testing
 	assert.Equal(t, "**/*.go", results[0].ADR.Scope)
 }
 
+func TestPgStore_Integration_BuildIndexReturnsErrorOnScanFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	connStr := setupPgContainer(t, ctx)
+
+	store, err := index.NewPgStore(connStr, "scan_failure_project", 5, index.HNSWOptions{})
+	require.NoError(t, err)
+	defer store.Close()
+	require.NoError(t, store.Load("", "test-model", 2, ""))
+
+	// A valid row plus one with a NULL title (a nullable TEXT column),
+	// proving the failure amid several rows, not a single-row table.
+	_, err = store.Pool().Exec(ctx, `
+		INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, "scan_failure_project", "0002-good.md", "Good ADR", "Accepted", "other content", pgvector.NewVector([]float32{0.1, 0.1}))
+	require.NoError(t, err)
+	_, err = store.Pool().Exec(ctx, `
+		INSERT INTO archguard_adrs (project_name, rel_path, title, status, content, embedding)
+		VALUES ($1, $2, NULL, $3, $4, $5)
+	`, "scan_failure_project", "0001-bad.md", "Accepted", "content", pgvector.NewVector([]float32{0.1, 0.1}))
+	require.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "0001-bad.md"), []byte("---\ntitle: \"Bad ADR\"\nstatus: \"Accepted\"\n---\ncontent"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "0002-good.md"), []byte("---\ntitle: \"Good ADR\"\nstatus: \"Accepted\"\n---\nother content"), 0644))
+
+	provider := mockEmbedProvider()
+	localProvider := index.NewLocalProvider(tmpDir, []string{"Accepted"})
+
+	err = store.BuildIndex(ctx, "test-model", 2, provider, localProvider)
+	require.Error(t, err, "a Scan failure on one row must fail BuildIndex, not be silently dropped")
+	assert.Contains(t, err.Error(), "failed to scan existing ADR row")
+}
+
 // fakeContentProvider is a minimal analysis.ContentProvider for exercising
 // Engine.Run against a real PgStore without needing git plumbing.
 type fakeContentProvider struct {


### PR DESCRIPTION
## Summary

`PgStore.BuildIndex`'s `existingMap` read loop names a `rows.Scan` failure explicitly (`"failed to scan existing ADR row: %w"`) instead of `continue`-ing past it. Note on scope, found during review (see below): pgx v5's `Scan()` failure already ends row iteration and surfaces via the `rows.Err()` check #119 added, so this row was never truly silently swallowed at runtime -- but the resulting `"failed to read existing ADRs"` message didn't distinguish a scan failure from any other iteration-level error. This change makes that failure mode explicit and easier to debug.

## Related issue

Closes #120

## In scope

- `internal/index/pgvector.go`: `BuildIndex`'s existing-ADR read loop returns a named, wrapped error on a `rows.Scan` failure
- `internal/index/pgvector_integration_test.go`: new regression test proving the failure surfaces amid several rows (a valid row alongside a `NULL`-title row), not just in a degenerate single-row case

## Out of scope

- **`PgStore.Search` has the real, more severe instance of this bug class**: no `rows.Err()` check after its loop at all, and the `VectorStore` interface's `Search` method has no error return whatsoever -- so a per-row Scan failure there silently truncates the result set (including every ADR ranked after the failure point, not just the bad row) with only a `fmt.Printf` warning. Fixing this needs an interface-signature change affecting both `PgStore.Search` and `LocalStore.Search` plus every call site -- materially larger than this PR's single-function fix. Filed as **#124** to track separately.

## Architectural notes

None — no new invariant beyond the more specific error message; no interface change.

## Follow-ups

- #124 (see Out of scope above)

## Checklist

- [x] Title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `build(deps):`, etc.)
- [x] All acceptance criteria from the linked issue are met
- [x] `go test -race -cover ./...` passes
- [x] `golangci-lint run --timeout=5m` is clean
- [x] `CLAUDE.md` updated if this changes build/test commands, adds or renames a top-level package, changes a cross-package interface, or adds a footgun (N/A)
- [x] A new ADR added under `docs/arch/` if this embodies an architecturally-significant decision (N/A)
- [x] Comments follow the 2-line-max, WHY-only convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)